### PR TITLE
Add compile-time type-level arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
 # type-level-natural-numbers
-Abusing the type system to define the Naturals and perform arithmetic and boolean operations over them. 
+
+Abusing the type system to define the Naturals and perform arithmetic and boolean operations over them.
+
+## Peano encoding
+
+Natural numbers are encoded as types using the [Peano axioms](https://en.wikipedia.org/wiki/Peano_axioms):
+
+- `Zero` represents 0
+- `AddOne<N>` represents the successor of N (i.e. N + 1)
+
+For example, `AddOne<AddOne<Zero>>` is the type-level representation of 2. Convenience aliases `N0`..`N6` and runtime metatype bindings (`Zip`, `One`, `Two`, ..., `Six`) are provided.
+
+## Runtime arithmetic
+
+Free-function operators `+`, `*`, `<`, `>` work on existential metatype values (`any Natural.Type`). These are resolved at runtime via dynamic dispatch on `predecessorOrNil` / `successor`.
+
+```swift
+assert(One + Two == Three)
+assert(Two > One)
+```
+
+## Type-level arithmetic
+
+A parallel compile-time arithmetic system lets the Swift type checker verify equalities statically.
+
+### `NaturalExpression`
+
+```swift
+protocol NaturalExpression {
+    associatedtype Result: Natural
+}
+```
+
+A type-level computation that evaluates to a `Natural` type.
+
+### `Sum<L, R>`
+
+```swift
+assertEqual(Sum<N2, N2>.Result.self, Four)  // 2 + 2 = 4
+```
+
+`Sum<L, R>.Result` resolves to the concrete `AddOne<...>` chain representing L + R at compile time. The base case (`L == Zero`) conforms `Sum` to `NaturalExpression`; recursive cases use constrained extensions.
+
+### `Product<L, R>`
+
+```swift
+assertEqual(Product<N2, N3>.Result.self, Six)  // 2 * 3 = 6
+```
+
+`Product<L, R>.Result` resolves to L * R. The base cases (`L == Zero`, `L == N1`) are generic over R. For larger L values, specific (L, R) pairs are enumerated because Swift's type system cannot resolve a generic `Sum<R, R>.Result` at definition time (there are no generic associated types).
+
+### `assertEqual`
+
+```swift
+func assertEqual<T: Natural>(_: T.Type, _: T.Type) {}
+```
+
+A compile-time type equality assertion. If both arguments have the same static type the call compiles; if they differ, the compiler reports a type error. The function body is intentionally empty -- the assertion is the compilation itself.
+
+### How it differs from runtime arithmetic
+
+| | Runtime | Type-level |
+|---|---|---|
+| Values | Existential metatypes (`any Natural.Type`) | Concrete generic types (`N3.Type`) |
+| Dispatch | Dynamic (`predecessorOrNil` checks) | Static (type checker resolves `AddOne<...>` chains) |
+| Errors | Runtime assertion failures | Compile-time type errors |
+| Generality | Works for any natural number | `Sum` supports L up to N3; `Product` enumerates specific pairs for L >= 2 |
+
+### Why conditional conformance is limited
+
+Swift does not allow multiple conditional conformances of the same protocol on a single type. The natural encoding of type-level Peano addition would use two conformances of `Sum` to `NaturalExpression` (one for `L == Zero`, another for `L: Positive`), but the compiler rejects this. The workaround uses a single protocol conformance for the base case and plain constrained-extension typealiases for the recursive cases. This means `Sum<L, R>` only conforms to `NaturalExpression` when `L == Zero`, but `Sum<L, R>.Result` is available for any supported L value via the constrained extensions.

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -27,6 +27,14 @@ enum AddOne<Predecessor: Natural>: Positive {
     static var successor: AddOne<Self>.Type { AddOne<Self>.self }
 }
 
+typealias N0 = Zero
+typealias N1 = AddOne<N0>
+typealias N2 = AddOne<N1>
+typealias N3 = AddOne<N2>
+typealias N4 = AddOne<N3>
+typealias N5 = AddOne<N4>
+typealias N6 = AddOne<N5>
+
 let One = AddOne<Zero>.self
 
 assert(One == One)
@@ -103,3 +111,89 @@ func ><T: Positive, U: Positive>(lhs: T.Type, rhs: U.Type) -> Bool {
 assert(Two > One)
 assert(!(Zip > Zip))
 assert(Two > One)
+
+let Four = Three.successor
+let Five = Four.successor
+let Six = Five.successor
+
+// MARK: - Type-level arithmetic
+
+/// A type-level computation that evaluates to a `Natural` type.
+protocol NaturalExpression {
+    associatedtype Result: Natural
+}
+
+// MARK: Sum
+
+/// Type-level addition. `Sum<L, R>.Result` resolves to the concrete
+/// `AddOne<...>` chain representing L + R at compile time.
+///
+/// Swift does not support multiple conditional conformances of the same
+/// protocol, so the base case (L == Zero) uses a protocol conformance
+/// while the recursive cases use constrained extensions with typealiases.
+enum Sum<L: Natural, R: Natural> {}
+
+extension Sum: NaturalExpression where L == Zero {
+    typealias Result = R                                    // 0 + R = R
+}
+
+extension Sum where L == N1 {
+    typealias Result = AddOne<R>                            // 1 + R = R + 1
+}
+
+extension Sum where L == N2 {
+    typealias Result = AddOne<AddOne<R>>                    // 2 + R = R + 2
+}
+
+extension Sum where L == N3 {
+    typealias Result = AddOne<AddOne<AddOne<R>>>            // 3 + R = R + 3
+}
+
+// MARK: Product
+
+/// Type-level multiplication. `Product<L, R>.Result` resolves to the
+/// concrete `AddOne<...>` chain representing L * R at compile time.
+///
+/// The base cases (L == Zero, L == N1) are generic over R. For larger L
+/// values, Swift cannot resolve `Sum<R, R>.Result` for a generic R at
+/// definition time, so specific (L, R) pairs are enumerated.
+enum Product<L: Natural, R: Natural> {}
+
+extension Product: NaturalExpression where L == Zero {
+    typealias Result = Zero                                 // 0 * R = 0
+}
+
+extension Product where L == N1 {
+    typealias Result = R                                    // 1 * R = R
+}
+
+extension Product where L == N2, R == N1 {
+    typealias Result = N2                                   // 2 * 1 = 2
+}
+
+extension Product where L == N2, R == N2 {
+    typealias Result = N4                                   // 2 * 2 = 4
+}
+
+extension Product where L == N2, R == N3 {
+    typealias Result = N6                                   // 2 * 3 = 6
+}
+
+/// Compile-time type equality assertion. If both arguments have the same
+/// static type the call compiles; if they differ, the compiler reports a
+/// type error. The function body is intentionally empty -- the assertion
+/// is the compilation itself.
+func assertEqual<T: Natural>(_: T.Type, _: T.Type) {}
+
+// Compile-time addition
+assertEqual(Sum<N0, N0>.Result.self, Zip)
+assertEqual(Sum<N1, N0>.Result.self, One)
+assertEqual(Sum<N0, N1>.Result.self, One)
+assertEqual(Sum<N1, N2>.Result.self, Three)    // 1 + 2 = 3
+assertEqual(Sum<N2, N2>.Result.self, Four)     // 2 + 2 = 4
+
+// Compile-time multiplication
+assertEqual(Product<N0, N1>.Result.self, Zip)  // 0 * 1 = 0
+assertEqual(Product<N1, N2>.Result.self, Two)  // 1 * 2 = 2
+assertEqual(Product<N2, N2>.Result.self, Four) // 2 * 2 = 4
+assertEqual(Product<N2, N3>.Result.self, Six)  // 2 * 3 = 6


### PR DESCRIPTION
## Summary

- Add `Sum<L, R>.Result` and `Product<L, R>.Result` for compile-time type-level addition and multiplication
- Add `NaturalExpression` protocol, `assertEqual` compile-time assertion, and `N0`..`N6` type aliases
- Rewrite README documenting both runtime and type-level arithmetic systems

Closes #1

## Design notes

Swift rejects multiple conditional conformances of the same protocol, so `Sum` uses a protocol conformance for the base case (`L == Zero`) and constrained-extension typealiases for recursive cases. `Product` enumerates specific (L, R) pairs for L >= 2 because `Sum<R, R>.Result` cannot be resolved for generic R at definition time.

## Test plan

- [x] `swiftc type-level-natural-numbers/main.swift` compiles (all `assertEqual` calls type-check)
- [x] All existing runtime `assert()` calls pass