### PR TITLE
Add negative numbers via symmetric SubOne

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Project overview
+
+A single-file Swift project (`type-level-natural-numbers/main.swift`) that encodes the integers as types using the Peano axioms and implements arithmetic and comparison via existential metatypes.
+
+## Building and testing
+
+This is an Xcode command-line tool project. Build and run with:
+
+```sh
+xcodebuild -project type-level-natural-numbers.xcodeproj -scheme type-level-natural-numbers -configuration Debug build
+```
+
+Or open the `.xcodeproj` in Xcode and run. There is no separate test target -- correctness is verified by `assert` statements that execute when the program runs. A clean run with no assertion failures means all checks pass.
+
+## Code conventions
+
+- All code lives in a single file: `type-level-natural-numbers/main.swift`.
+- Integers are represented as types (`Zero`, `AddOne<N>`, `SubOne<N>`) conforming to protocols in the `Integer` hierarchy.
+- The protocol hierarchy is: `Integer` (root) -> `Natural`/`Nonpositive` -> `Positive`/`Negative`. `Zero` conforms to both `Natural` and `Nonpositive`.
+- Runtime values are existential metatypes (`any Integer.Type`, `any Natural.Type`, `any Positive.Type`, etc.).
+- Operator overloads use the tightest return type possible (e.g. `Positive + Natural -> Positive`).
+- Recursive definitions follow Peano-style induction: base case on `Zero`, inductive step via `predecessor`/`successor`.
+- Zero is detected by casting (`as? any Positive.Type`, `as? any Negative.Type`) rather than optional checks.
+- Assertions serve as inline tests and are grouped immediately after the code they exercise.
+
+## Branching
+
+- `master` -- runtime arithmetic (addition, multiplication, comparison).
+- `worktree-type-level-arithmetic` -- extends master with compile-time type-level arithmetic (`Sum`, `Product`, `NaturalExpression`, `assertEqual`).
+- `worktree-integer-extension` -- extends master with negative numbers via `SubOne`, negation, subtraction, and integer-level arithmetic.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,134 @@
 # type-level-natural-numbers
-Abusing the type system to define the Naturals and perform arithmetic and boolean operations over them. 
+
+Encoding the integers as Swift types using the Peano axioms and performing arithmetic and comparison over them at runtime via existential metatypes.
+
+## Peano encoding
+
+Numbers are represented as types:
+
+- `Zero` represents 0
+- `AddOne<N>` represents the successor of N (i.e. N + 1)
+- `SubOne<N>` represents the predecessor of N (i.e. N - 1)
+
+For example, `AddOne<AddOne<Zero>>` is the type-level representation of 2, and `SubOne<Zero>` is -1. Runtime metatype bindings (`Zip`, `One`, `Two`, ..., `Six`, `MinusOne`, `MinusTwo`, `MinusThree`) provide convenient handles.
+
+## Protocols
+
+### `Integer`
+
+The root protocol for all integer types. Declares `Successor` and `Predecessor` associated types with `successor` and `predecessor` properties.
+
+### `Natural`
+
+Extends `Integer` for nonnegative integers (0, 1, 2, ...). Constrains `Successor` to `Positive`. Conformed to by `Zero` and `AddOne<N>`.
+
+### `Positive`
+
+A refinement of `Natural` for numbers >= 1. Constrains `Predecessor` to `Natural`. `AddOne<N>` conforms to `Positive` for any `N: Natural`.
+
+### `Nonpositive`
+
+Extends `Integer` for nonpositive integers (0, -1, -2, ...). Constrains `Predecessor` to `Negative`. Conformed to by `Zero` and `SubOne<N>`.
+
+### `Negative`
+
+A refinement of `Nonpositive` for numbers <= -1. Constrains `Successor` to `Nonpositive`. `SubOne<N>` conforms to `Negative` for any `N: Nonpositive`.
+
+`Zero` sits at the intersection of `Natural` and `Nonpositive`, conforming to both.
+
+## Arithmetic
+
+Free-function operators work on existential metatypes (`any Natural.Type`, `any Positive.Type`, `any Integer.Type`). They are defined recursively using `predecessor` and `successor`.
+
+### Addition (`+`)
+
+Natural-level overloads provide tighter return types:
+
+| Signature | Return type |
+|---|---|
+| `(any Natural.Type, any Natural.Type)` | `any Natural.Type` |
+| `(any Natural.Type, any Positive.Type)` | `any Positive.Type` |
+| `(any Positive.Type, any Natural.Type)` | `any Positive.Type` |
+| `(any Positive.Type, any Positive.Type)` | `any Positive.Type` |
+
+An integer-level overload handles mixed-sign addition:
+
+| `(any Integer.Type, any Integer.Type)` | `any Integer.Type` |
+
+A `Zero`-specific static overload handles `0 + 0` without recursion.
+
+### Subtraction (`-`)
+
+Defined as addition of the negation:
+
+```swift
+func -(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type
+```
+
+### Multiplication (`*`)
+
+Static overloads on `Natural` handle the base cases (`0 * n` and `n * 0`). A free-function recursive definition covers the general case:
+
+```
+(n+1) * m = n * m + m
+```
+
+with a short-circuit for `1 * m = m`.
+
+An integer-level overload extends multiplication to negative numbers:
+
+```
+(-1) * m = -m
+(n-1) * m = n * m - m
+```
+
+### Negation
+
+```swift
+func negate(_ n: any Integer.Type) -> any Integer.Type
+```
+
+Recursively negates a number by walking toward zero and rebuilding in the opposite direction.
+
+### Comparison (`<`, `>`)
+
+Natural-level `<` recurses on predecessors:
+
+```
+0 < 0       = false
+0 < (n+1)   = true
+(n+1) < 0   = false
+(n+1) < (m+1) = n < m
+```
+
+Integer-level `<` handles mixed signs:
+- Any negative < any nonnegative
+- Any nonnegative > any negative
+- Both nonnegative: delegates to natural comparison
+- Both negative: `SubOne<a> < SubOne<b>` iff `a < b`
+
+`>` is defined as the flip of `<` at both levels.
+
+## Examples
+
+```swift
+let One   = AddOne<Zero>.self
+let Two   = One.successor
+let Three = Two.successor
+
+assert(One + Two == Three)
+assert(Two * Two == Four)
+assert(Two > One)
+assert(!(Zip < Zip))
+
+let MinusOne = SubOne<Zero>.self
+assert(One + MinusOne == Zip)
+assert(Three - Two == One)
+assert(Two - Three == MinusOne)
+assert(MinusOne * MinusOne == One)
+assert(MinusOne < Zip)
+```
+
+## Building
+
+Open `type-level-natural-numbers.xcodeproj` in Xcode and run the target. The program exercises every operation via `assert` statements -- a successful run means all checks pass.

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -1,15 +1,33 @@
-protocol Natural {
-    associatedtype Successor: Positive
-    static var successor: Successor.Type { get }
-}
+// MARK: - Protocol hierarchy
 
-protocol Positive: Natural {
-    associatedtype Predecessor: Natural
+protocol Integer {
+    associatedtype Successor: Integer
+    associatedtype Predecessor: Integer
+    static var successor: Successor.Type { get }
     static var predecessor: Predecessor.Type { get }
 }
 
-enum Zero: Natural {
+protocol Natural: Integer where Successor: Positive {}
+
+protocol Positive: Natural where Predecessor: Natural {}
+
+protocol Nonpositive: Integer where Predecessor: Negative {}
+
+protocol Negative: Nonpositive where Successor: Nonpositive {}
+
+// MARK: - Types
+
+enum SubOne<Successor: Nonpositive>: Negative {
+    typealias Predecessor = SubOne<Self>
+    static var successor: Successor.Type { Successor.self }
+    static var predecessor: SubOne<Self>.Type { SubOne<Self>.self }
+}
+
+enum Zero: Natural, Nonpositive {
+    typealias Successor = AddOne<Zero>
+    typealias Predecessor = SubOne<Zero>
     static var successor: AddOne<Zero>.Type { AddOne<Zero>.self }
+    static var predecessor: SubOne<Zero>.Type { SubOne<Zero>.self }
 }
 
 let Zip = Zero.self
@@ -23,6 +41,7 @@ extension Zero {
 }
 
 enum AddOne<Predecessor: Natural>: Positive {
+    typealias Successor = AddOne<Self>
     static var predecessor: Predecessor.Type { Predecessor.self }
     static var successor: AddOne<Self>.Type { AddOne<Self>.self }
     
@@ -42,6 +61,19 @@ let Two = One.successor
 assert(Two != One)
 assert(Two.predecessor == One)
 
+// MARK: - Negative convenience bindings
+
+let MinusOne   = SubOne<Zero>.self
+let MinusTwo   = SubOne<SubOne<Zero>>.self
+let MinusThree = SubOne<SubOne<SubOne<Zero>>>.self
+
+assert(MinusOne != Zip)
+assert(MinusOne != One)
+assert(MinusOne.successor == Zip)
+assert(MinusTwo.successor == MinusOne)
+
+// MARK: - Natural addition
+
 assert(Zip + Zip == Zip)
 assert(Zip + One == One)
 assert(One + Zip == One)
@@ -52,7 +84,6 @@ func +(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
     let plhs = lhs as! any Positive.Type
     return plhs.predecessor + rhs.successor
 }
-
 
 func +(lhs: any Natural.Type, rhs: any Positive.Type) -> any Positive.Type {
     if lhs == Zero.self {
@@ -77,43 +108,30 @@ let Three = Two.successor
 
 assert(One + Two == Three)
 
-func <<T: Natural, U: Natural>(lhs: T.Type, rhs: U.Type) -> Bool {
-    if lhs == rhs {
-        return false
-    }
-    
-    if lhs == Zero.self {
-        return true
-    } else if rhs == Zero.self {
-        return false
-    }
-    
-    fatalError()
-}
+// MARK: - Natural comparison
 
-func <<T: Positive, U: Positive>(lhs: T.Type, rhs: U.Type) -> Bool {
-    if lhs == rhs {
-        return false
+func <(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
+    switch (lhs as? any Positive.Type, rhs as? any Positive.Type) {
+    case (nil, nil):         return false     // 0 < 0
+    case (nil, _):           return true      // 0 < n+1
+    case (_, nil):           return false     // n+1 < 0
+    case let (lp?, rp?):     return lp.predecessor < rp.predecessor
     }
-    
-    return lhs.predecessor < rhs.predecessor
 }
 
 assert(!(Zip < Zip))
 assert(One < Two)
 assert(!(Two < One))
 
-func ><T: Natural, U: Natural>(lhs: T.Type, rhs: U.Type) -> Bool {
-    rhs < lhs
-}
-
-func ><T: Positive, U: Positive>(lhs: T.Type, rhs: U.Type) -> Bool {
+func >(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
     rhs < lhs
 }
 
 assert(Two > One)
 assert(!(Zip > Zip))
 assert(Two > One)
+
+// MARK: - Natural multiplication
 
 extension Natural {
     static func *(lhs: Zero.Type, rhs: Self.Type) -> Zero.Type {
@@ -148,3 +166,96 @@ assert(Three * Two == Six)
 assert(One * One == One)
 assert(Four * One == Four)
 assert(One * Four == Four)
+
+assert(Two + Two == Four)
+assert(Two + Zip == Two)
+
+// MARK: - Negation
+
+func negate(_ n: any Integer.Type) -> any Integer.Type {
+    if n == Zero.self { return n }
+    if let pos = n as? any Positive.Type {
+        return negate(pos.predecessor as any Integer.Type).predecessor
+    }
+    let neg = n as! any Negative.Type
+    return negate(neg.successor as any Integer.Type).successor
+}
+
+assert(negate(Zip) == Zip)
+assert(negate(One) == MinusOne)
+assert(negate(MinusOne) == One)
+assert(negate(Two) == MinusTwo)
+assert(negate(MinusTwo) == Two)
+
+// MARK: - Integer addition
+
+func +(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type {
+    if lhs == Zero.self { return rhs }
+    if rhs == Zero.self { return lhs }
+    if let pos = lhs as? any Positive.Type {
+        return (pos.predecessor as any Integer.Type) + rhs.successor   // (n+1) + m = n + (m+1)
+    }
+    let neg = lhs as! any Negative.Type
+    return (neg.successor as any Integer.Type) + rhs.predecessor       // (n-1) + m = n + (m-1)
+}
+
+assert(One + MinusOne == Zip)
+assert(MinusOne + One == Zip)
+assert(MinusOne + MinusOne == MinusTwo)
+assert(Three + MinusTwo == One)
+assert(MinusTwo + Three == One)
+
+// MARK: - Subtraction
+
+func -(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type {
+    lhs + negate(rhs)
+}
+
+assert(Three - Two == One)
+assert(Two - Three == MinusOne)
+assert(Zip - One == MinusOne)
+assert(One - Zip == One)
+assert(MinusOne - MinusOne == Zip)
+
+// MARK: - Integer multiplication
+
+func *(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type {
+    if lhs == Zero.self || rhs == Zero.self { return Zero.self }
+    if let pos = lhs as? any Positive.Type {
+        if pos.predecessor == Zero.self { return rhs }                        // 1 * m = m
+        return (pos.predecessor as any Integer.Type) * rhs + rhs              // (n+1) * m = n*m + m
+    }
+    let neg = lhs as! any Negative.Type
+    if neg.successor == Zero.self { return negate(rhs) }                      // (-1) * m = -m
+    return (neg.successor as any Integer.Type) * rhs - rhs                    // (n-1) * m = n*m - m
+}
+
+assert(MinusOne * One == MinusOne)
+assert(MinusOne * MinusOne == One)
+assert(Two * MinusThree == negate(Six))
+assert(MinusTwo * Three == negate(Six))
+assert(MinusTwo * MinusThree == Six)
+
+// MARK: - Integer comparison
+
+func <(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
+    if lhs is any Negative.Type && !(rhs is any Negative.Type) { return true }
+    if !(lhs is any Negative.Type) && rhs is any Negative.Type { return false }
+    if let ln = lhs as? any Natural.Type, let rn = rhs as? any Natural.Type {
+        return ln < rn  // both nonnegative -- use Natural overload
+    }
+    // both negative: SubOne<a> < SubOne<b> iff a < b
+    return lhs.successor < rhs.successor
+}
+
+func >(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
+    rhs < lhs
+}
+
+assert(MinusOne < Zip)
+assert(MinusTwo < MinusOne)
+assert(!(MinusOne < MinusOne))
+assert(MinusOne < One)
+assert(!(One < MinusOne))
+assert(One > MinusOne)
+assert(MinusOne > MinusTwo)


### PR DESCRIPTION
## Summary
- Add `Integer` as root protocol with `Nonpositive`/`Negative` protocols mirroring `Natural`/`Positive`
- Add `SubOne<N: Nonpositive>` type mirroring `AddOne<N: Natural>` for negative numbers
- Implement negation, subtraction, and integer-level addition/multiplication/comparison

## Test plan
- [x] All existing Natural-level assertions still pass (regression)
- [x] Negative convenience bindings (`MinusOne`, `MinusTwo`, `MinusThree`) with successor assertions
- [x] Negation: `negate(One) == MinusOne`, `negate(MinusTwo) == Two`, etc.
- [x] Mixed-sign addition: `One + MinusOne == Zip`, `Three + MinusTwo == One`
- [x] Subtraction: `Three - Two == One`, `Two - Three == MinusOne`
- [x] Mixed-sign multiplication: `MinusOne * MinusOne == One`, `Two * MinusThree == negate(Six)`
- [x] Integer comparison: `MinusOne < Zip`, `MinusTwo < MinusOne`, `One > MinusOne`

Closes #3