### PR TITLE
Simplify protocol hierarchy to 3 protocols and switch to right-hand recursion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,11 @@ The Xcode target is self-contained -- it does not depend on the SPM package. It 
 ## Code conventions
 
 - Integers are represented as types (`Zero`, `AddOne<N>`, `SubOne<N>`) conforming to protocols in the `Integer` hierarchy.
-- The protocol hierarchy is: `Integer` (root) -> `Natural`/`Nonpositive` -> `Positive`/`Negative`. `Zero` conforms to both `Natural` and `Nonpositive`.
-- Runtime values are existential metatypes (`any Integer.Type`, `any Natural.Type`, `any Positive.Type`, etc.).
-- Operator overloads use the tightest return type possible (e.g. `Positive + Natural -> Positive`).
-- Recursive definitions follow Peano-style induction: base case on `Zero`, inductive step via `predecessor`/`successor`.
-- Zero is detected by casting (`as? any Positive.Type`, `as? any Negative.Type`) rather than optional checks.
+- The protocol hierarchy has 3 protocols: `Integer` (root) -> `Natural` and `Nonpositive`. `Zero` conforms to both `Natural` and `Nonpositive`.
+- Runtime values are existential metatypes (`any Integer.Type`, `any Natural.Type`, `any Nonpositive.Type`).
+- Operator overloads use the tightest return type available (e.g. `Natural + Natural -> Natural`, `Integer + Integer -> Integer`).
+- All operators use right-hand recursion (standard Peano form): base case when `rhs == Zero`, inductive step peels the successor off the right operand.
+- Zero is detected by `== Zero.self` comparison. Non-zero naturals are detected by `as? any Natural.Type` cast after excluding zero.
 - Assertions serve as inline tests and are grouped immediately after the code they exercise.
 
 ## Branching
@@ -70,3 +70,4 @@ The Xcode target is self-contained -- it does not depend on the SPM package. It 
 - `worktree-type-level-arithmetic` -- extends master with compile-time type-level arithmetic (`Sum`, `Product`, `NaturalExpression`, `assertEqual`).
 - `worktree-integer-extension` -- extends master with negative numbers via `SubOne`, negation, subtraction, and integer-level arithmetic.
 - `worktree-macros` -- extends integer-extension with Swift macros (`#Peano`, `#PeanoType`, `#PeanoAssert`) for compile-time arithmetic.
+- `worktree-simplify-protocols` -- extends macros: simplifies to 3 protocols, switches to right-hand recursion, adds `<=`/`>=`.

--- a/README.md
+++ b/README.md
@@ -14,46 +14,36 @@ For example, `AddOne<AddOne<Zero>>` is the type-level representation of 2, and `
 
 ## Protocols
 
+The protocol hierarchy uses 3 protocols:
+
 ### `Integer`
 
 The root protocol for all integer types. Declares `Successor` and `Predecessor` associated types with `successor` and `predecessor` properties.
 
 ### `Natural`
 
-Extends `Integer` for nonnegative integers (0, 1, 2, ...). Constrains `Successor` to `Positive`. Conformed to by `Zero` and `AddOne<N>`.
-
-### `Positive`
-
-A refinement of `Natural` for numbers >= 1. Constrains `Predecessor` to `Natural`. `AddOne<N>` conforms to `Positive` for any `N: Natural`.
+Extends `Integer` for nonnegative integers (0, 1, 2, ...). Constrains `Successor` to `Natural`. Conformed to by `Zero` and `AddOne<N>`.
 
 ### `Nonpositive`
 
-Extends `Integer` for nonpositive integers (0, -1, -2, ...). Constrains `Predecessor` to `Negative`. Conformed to by `Zero` and `SubOne<N>`.
+Extends `Integer` for nonpositive integers (0, -1, -2, ...). Constrains `Predecessor` to `Nonpositive`. Conformed to by `Zero` and `SubOne<N>`.
 
-### `Negative`
-
-A refinement of `Nonpositive` for numbers <= -1. Constrains `Successor` to `Nonpositive`. `SubOne<N>` conforms to `Negative` for any `N: Nonpositive`.
-
-`Zero` sits at the intersection of `Natural` and `Nonpositive`, conforming to both.
+`Zero` sits at the intersection of `Natural` and `Nonpositive`, conforming to both. Type canonicalization is enforced by the generic parameter constraints: `AddOne<N: Natural>` prevents `AddOne<SubOne<...>>`, and `SubOne<N: Nonpositive>` prevents `SubOne<AddOne<...>>`.
 
 ## Arithmetic
 
-Free-function operators work on existential metatypes (`any Natural.Type`, `any Positive.Type`, `any Integer.Type`). They are defined recursively using `predecessor` and `successor`.
+Free-function operators work on existential metatypes (`any Natural.Type`, `any Integer.Type`). All operators use right-hand recursion (the standard Peano form), reducing the right operand toward zero.
 
 ### Addition (`+`)
 
-Natural-level overloads provide tighter return types:
+Right-hand recursive definition:
 
-| Signature | Return type |
-|---|---|
-| `(any Natural.Type, any Natural.Type)` | `any Natural.Type` |
-| `(any Natural.Type, any Positive.Type)` | `any Positive.Type` |
-| `(any Positive.Type, any Natural.Type)` | `any Positive.Type` |
-| `(any Positive.Type, any Positive.Type)` | `any Positive.Type` |
+```
+a + 0    = a         (base case)
+a + S(b) = S(a + b)  (inductive step)
+```
 
-An integer-level overload handles mixed-sign addition:
-
-| `(any Integer.Type, any Integer.Type)` | `any Integer.Type` |
+An integer-level overload handles mixed-sign addition by recursing on the rhs toward zero via `successor` (for negative rhs) or `predecessor` (for positive rhs).
 
 A `Zero`-specific static overload handles `0 + 0` without recursion.
 
@@ -67,19 +57,21 @@ func -(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type
 
 ### Multiplication (`*`)
 
-Static overloads on `Natural` handle the base cases (`0 * n` and `n * 0`). A free-function recursive definition covers the general case:
+Right-hand recursive definition:
 
 ```
-(n+1) * m = n * m + m
+a * 0    = 0             (base case)
+a * S(b) = a * b + a     (inductive step)
 ```
 
-with a short-circuit for `1 * m = m`.
+Static overloads on `Natural` handle the base cases (`0 * n` and `n * 0`).
 
 An integer-level overload extends multiplication to negative numbers:
 
 ```
-(-1) * m = -m
-(n-1) * m = n * m - m
+a * 0    = 0
+a * S(b) = a * b + a     (positive rhs)
+a * P(b) = a * b - a     (negative rhs)
 ```
 
 ### Negation
@@ -90,15 +82,14 @@ func negate(_ n: any Integer.Type) -> any Integer.Type
 
 Recursively negates a number by walking toward zero and rebuilding in the opposite direction.
 
-### Comparison (`<`, `>`)
+### Comparison (`<`, `>`, `<=`, `>=`)
 
-Natural-level `<` recurses on predecessors:
+Natural-level `<` uses right-hand recursion:
 
 ```
-0 < 0       = false
-0 < (n+1)   = true
-(n+1) < 0   = false
-(n+1) < (m+1) = n < m
+a < 0    = false
+0 < S(b) = true
+S(a) < S(b) = a < b
 ```
 
 Integer-level `<` handles mixed signs:
@@ -107,7 +98,7 @@ Integer-level `<` handles mixed signs:
 - Both nonnegative: delegates to natural comparison
 - Both negative: `SubOne<a> < SubOne<b>` iff `a < b`
 
-`>` is defined as the flip of `<` at both levels.
+`>` is the flip of `<`. `<=` and `>=` are defined as `!(rhs < lhs)` and `!(lhs < rhs)` respectively, at both the natural and integer levels.
 
 ## Macros
 
@@ -163,11 +154,14 @@ let Three = #Peano(3)
 assert(One + Two == Three)
 assert(Two * Two == #Peano(4))
 assert(Two > One)
+assert(Two <= Two)
+assert(Two >= One)
 
 // Compile-time assertions (evaluated during macro expansion)
 #PeanoAssert(1 + 2 == 3)
 #PeanoAssert(2 * 3 == 6)
 #PeanoAssert(-1 < 0)
+#PeanoAssert(0 <= 0)
 
 // Type equality via assertEqual
 assertEqual(#PeanoType(2 + 3), #Peano(5))

--- a/Sources/PeanoNumbersClient/main.swift
+++ b/Sources/PeanoNumbersClient/main.swift
@@ -45,6 +45,17 @@ assert(!(Two < One))
 assert(Two > One)
 assert(!(Zip > Zip))
 
+// MARK: - Comparison (<=, >=)
+
+assert(Zip <= Zip)
+assert(One <= Two)
+assert(Two <= Two)
+assert(!(Two <= One))
+assert(Zip >= Zip)
+assert(Two >= One)
+assert(Two >= Two)
+assert(!(One >= Two))
+
 // MARK: - Multiplication
 
 assert(Zip * One == Zip)
@@ -98,6 +109,15 @@ assert(MinusOne < One)
 assert(!(One < MinusOne))
 assert(One > MinusOne)
 assert(MinusOne > MinusTwo)
+
+// MARK: - Integer comparison (<=, >=)
+
+assert(MinusOne <= Zip)
+assert(MinusOne <= MinusOne)
+assert(!(Zip <= MinusOne))
+assert(Zip >= MinusOne)
+assert(MinusOne >= MinusOne)
+assert(!(MinusOne >= Zip))
 
 // MARK: - Compile-time type equality assertions (verified at build time)
 

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -7,17 +7,13 @@ protocol Integer {
     static var predecessor: Predecessor.Type { get }
 }
 
-protocol Natural: Integer where Successor: Positive {}
+protocol Natural: Integer where Successor: Natural {}
 
-protocol Positive: Natural where Predecessor: Natural {}
-
-protocol Nonpositive: Integer where Predecessor: Negative {}
-
-protocol Negative: Nonpositive where Successor: Nonpositive {}
+protocol Nonpositive: Integer where Predecessor: Nonpositive {}
 
 // MARK: - Types
 
-enum SubOne<Successor: Nonpositive>: Negative {
+enum SubOne<Successor: Nonpositive>: Nonpositive {
     typealias Predecessor = SubOne<Self>
     static var successor: Successor.Type { Successor.self }
     static var predecessor: SubOne<Self>.Type { SubOne<Self>.self }
@@ -40,7 +36,7 @@ extension Zero {
     }
 }
 
-enum AddOne<Predecessor: Natural>: Positive {
+enum AddOne<Predecessor: Natural>: Natural {
     typealias Successor = AddOne<Self>
     static var predecessor: Predecessor.Type { Predecessor.self }
     static var successor: AddOne<Self>.Type { AddOne<Self>.self }
@@ -68,47 +64,27 @@ assert(MinusOne != One)
 assert(MinusOne.successor == Zip)
 assert(MinusTwo.successor == MinusOne)
 
-// MARK: - Natural addition
+// MARK: - Natural addition (right-hand recursion)
 
 assert(Zip + Zip == Zip)
 assert(Zip + One == One)
 assert(One + Zip == One)
 
 func +(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
-    guard let pos = lhs as? any Positive.Type else { return rhs }  // 0 + m = m
-    if rhs == Zero.self { return lhs }                              // n + 0 = n
-    return pos.predecessor + rhs.successor                          // (n+1) + m = n + (m+1)
-}
-
-func +(lhs: any Natural.Type, rhs: any Positive.Type) -> any Positive.Type {
-    guard let pos = lhs as? any Positive.Type else { return rhs }
-    return pos.predecessor + rhs.successor
-}
-
-func +(lhs: any Positive.Type, rhs: any Natural.Type) -> any Positive.Type {
-    if rhs == Zero.self {
-        return lhs
-    }
-    return lhs.predecessor + rhs.successor
-}
-
-func +(lhs: any Positive.Type, rhs: any Positive.Type) -> any Positive.Type {
-    return lhs.predecessor + rhs.successor
+    if rhs == Zero.self { return lhs }                              // a + 0 = a
+    return (lhs + (rhs.predecessor as! any Natural.Type)).successor // a + S(b) = S(a + b)
 }
 
 let Three = Two.successor
 
 assert(One + Two == Three)
 
-// MARK: - Natural comparison
+// MARK: - Natural comparison (right-hand recursion)
 
 func <(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
-    switch (lhs as? any Positive.Type, rhs as? any Positive.Type) {
-    case (nil, nil):         return false     // 0 < 0
-    case (nil, _):           return true      // 0 < n+1
-    case (_, nil):           return false     // n+1 < 0
-    case let (lp?, rp?):     return lp.predecessor < rp.predecessor
-    }
+    if rhs == Zero.self { return false }                            // a < 0 = false
+    if lhs == Zero.self { return true }                             // 0 < S(b) = true
+    return (lhs.predecessor as! any Natural.Type) < (rhs.predecessor as! any Natural.Type)
 }
 
 assert(!(Zip < Zip))
@@ -121,9 +97,25 @@ func >(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
 
 assert(Two > One)
 assert(!(Zip > Zip))
-assert(Two > One)
 
-// MARK: - Natural multiplication
+func <=(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
+    !(rhs < lhs)
+}
+
+func >=(lhs: any Natural.Type, rhs: any Natural.Type) -> Bool {
+    !(lhs < rhs)
+}
+
+assert(Zip <= Zip)
+assert(One <= Two)
+assert(Two <= Two)
+assert(!(Two <= One))
+assert(Zip >= Zip)
+assert(Two >= One)
+assert(Two >= Two)
+assert(!(One >= Two))
+
+// MARK: - Natural multiplication (right-hand recursion)
 
 extension Natural {
     static func *(lhs: Zero.Type, rhs: Self.Type) -> Zero.Type {
@@ -136,10 +128,8 @@ extension Natural {
 }
 
 func *(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
-    guard let pos = lhs as? any Positive.Type else { return Zero.self }  // 0 * m = 0
-    if rhs == Zero.self { return Zero.self }                              // n * 0 = 0
-    if pos.predecessor == Zero.self { return rhs }                        // 1 * m = m
-    return pos.predecessor * rhs + rhs                                    // (n+1) * m = n*m + m
+    if rhs == Zero.self { return Zero.self }                        // a * 0 = 0
+    return lhs * (rhs.predecessor as! any Natural.Type) + lhs      // a * S(b) = a*b + a
 }
 
 assert(Zero.self * One == Zero.self)
@@ -166,11 +156,10 @@ assert(Two + Zip == Two)
 
 func negate(_ n: any Integer.Type) -> any Integer.Type {
     if n == Zero.self { return n }
-    if let pos = n as? any Positive.Type {
-        return negate(pos.predecessor as any Integer.Type).predecessor
+    if let nat = n as? any Natural.Type {
+        return negate(nat.predecessor as any Integer.Type).predecessor
     }
-    let neg = n as! any Negative.Type
-    return negate(neg.successor as any Integer.Type).successor
+    return negate(n.successor as any Integer.Type).successor
 }
 
 assert(negate(Zip) == Zip)
@@ -179,16 +168,14 @@ assert(negate(MinusOne) == One)
 assert(negate(Two) == MinusTwo)
 assert(negate(MinusTwo) == Two)
 
-// MARK: - Integer addition
+// MARK: - Integer addition (right-hand recursion on rhs)
 
 func +(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type {
-    if lhs == Zero.self { return rhs }
-    if rhs == Zero.self { return lhs }
-    if let pos = lhs as? any Positive.Type {
-        return (pos.predecessor as any Integer.Type) + rhs.successor   // (n+1) + m = n + (m+1)
+    if rhs == Zero.self { return lhs }                              // a + 0 = a
+    if rhs is any Natural.Type {
+        return ((lhs + (rhs.predecessor as any Integer.Type)) as any Integer.Type).successor
     }
-    let neg = lhs as! any Negative.Type
-    return (neg.successor as any Integer.Type) + rhs.predecessor       // (n-1) + m = n + (m-1)
+    return ((lhs + (rhs.successor as any Integer.Type)) as any Integer.Type).predecessor
 }
 
 assert(One + MinusOne == Zip)
@@ -209,17 +196,14 @@ assert(Zip - One == MinusOne)
 assert(One - Zip == One)
 assert(MinusOne - MinusOne == Zip)
 
-// MARK: - Integer multiplication
+// MARK: - Integer multiplication (right-hand recursion on rhs)
 
 func *(lhs: any Integer.Type, rhs: any Integer.Type) -> any Integer.Type {
     if lhs == Zero.self || rhs == Zero.self { return Zero.self }
-    if let pos = lhs as? any Positive.Type {
-        if pos.predecessor == Zero.self { return rhs }                        // 1 * m = m
-        return (pos.predecessor as any Integer.Type) * rhs + rhs              // (n+1) * m = n*m + m
+    if rhs is any Natural.Type {
+        return (lhs * (rhs.predecessor as any Integer.Type)) + lhs  // a * S(b) = a*b + a
     }
-    let neg = lhs as! any Negative.Type
-    if neg.successor == Zero.self { return negate(rhs) }                      // (-1) * m = -m
-    return (neg.successor as any Integer.Type) * rhs - rhs                    // (n-1) * m = n*m - m
+    return (lhs * (rhs.successor as any Integer.Type)) - lhs       // a * P(b) = a*b - a
 }
 
 assert(MinusOne * One == MinusOne)
@@ -231,17 +215,25 @@ assert(MinusTwo * MinusThree == Six)
 // MARK: - Integer comparison
 
 func <(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
-    if lhs is any Negative.Type && !(rhs is any Negative.Type) { return true }
-    if !(lhs is any Negative.Type) && rhs is any Negative.Type { return false }
     if let ln = lhs as? any Natural.Type, let rn = rhs as? any Natural.Type {
-        return ln < rn  // both nonnegative -- use Natural overload
+        return ln < rn
     }
-    // both negative: SubOne<a> < SubOne<b> iff a < b
+    if lhs is any Natural.Type { return false }  // nonneg >= negative
+    if rhs is any Natural.Type { return true }   // negative < nonneg
+    // both negative
     return lhs.successor < rhs.successor
 }
 
 func >(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
     rhs < lhs
+}
+
+func <=(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
+    !(rhs < lhs)
+}
+
+func >=(lhs: any Integer.Type, rhs: any Integer.Type) -> Bool {
+    !(lhs < rhs)
 }
 
 assert(MinusOne < Zip)
@@ -251,3 +243,10 @@ assert(MinusOne < One)
 assert(!(One < MinusOne))
 assert(One > MinusOne)
 assert(MinusOne > MinusTwo)
+
+assert(MinusOne <= Zip)
+assert(MinusOne <= MinusOne)
+assert(!(Zip <= MinusOne))
+assert(Zip >= MinusOne)
+assert(MinusOne >= MinusOne)
+assert(!(MinusOne >= Zip))


### PR DESCRIPTION
## Summary

- Remove `Positive` and `Negative` protocols, simplifying the hierarchy from 5 to 3 protocols
- Switch all operators to right-hand recursion (standard Peano form: `a + S(b) = S(a + b)`)
- Add `<=` and `>=` comparison operators at both Natural and Integer levels
- Update zero detection to use `== Zero.self` and `as? any Natural.Type` casts

Closes #7

## Test plan

- [x] `swift build` compiles without errors
- [x] `swift run PeanoNumbersClient` -- all runtime assertions pass (including new `<=`/`>=` tests)
- [x] `swift test` -- all 23 macro expansion tests pass
- [x] `xcodebuild` -- Xcode standalone target builds and runs