### PR TITLE
Add arithmetic extensions: exponentiation, monus, division, factorial, fibonacci, GCD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,4 @@ The Xcode target is self-contained -- it does not depend on the SPM package. It 
 - `worktree-integer-extension` -- extends master with negative numbers via `SubOne`, negation, subtraction, and integer-level arithmetic.
 - `worktree-macros` -- extends integer-extension with Swift macros (`#Peano`, `#PeanoType`, `#PeanoAssert`) for compile-time arithmetic.
 - `worktree-simplify-protocols` -- extends macros: simplifies to 3 protocols, switches to right-hand recursion, adds `<=`/`>=`.
+- `worktree-arithmetic-extensions` -- extends simplify-protocols: adds exponentiation, monus, division/modulo, factorial, fibonacci, GCD; extends macro evaluator.

--- a/Sources/PeanoNumbersClient/main.swift
+++ b/Sources/PeanoNumbersClient/main.swift
@@ -2,13 +2,16 @@ import PeanoNumbers
 
 // MARK: - Convenience bindings
 
-let Zip        = #Peano(0)
-let One        = #Peano(1)
-let Two        = #Peano(2)
-let Three      = #Peano(3)
-let Four       = #Peano(4)
-let Five       = #Peano(5)
-let Six        = #Peano(6)
+// Natural bindings are typed as `any Natural.Type` so they work with natural-only
+// operations (exponentiation, monus, division, factorial, fibonacci, gcd).
+// Since `Natural: Integer`, they also work with integer operations via covariance.
+let Zip: any Natural.Type   = Zero.self
+let One: any Natural.Type   = AddOne<Zero>.self
+let Two: any Natural.Type   = One.successor
+let Three: any Natural.Type = Two.successor
+let Four: any Natural.Type  = Three.successor
+let Five: any Natural.Type  = Four.successor
+let Six: any Natural.Type   = Five.successor
 
 let MinusOne   = #Peano(-1)
 let MinusTwo   = #Peano(-2)
@@ -119,6 +122,60 @@ assert(Zip >= MinusOne)
 assert(MinusOne >= MinusOne)
 assert(!(MinusOne >= Zip))
 
+// MARK: - Exponentiation
+
+assert(Two ** Three == #Peano(8))
+assert(Three ** Two == #Peano(9))
+assert(Two ** Zip == One)
+assert(Zip ** Five == Zip)
+assert(One ** Six == One)
+
+// MARK: - Integer exponentiation
+
+assert((MinusTwo as any Integer.Type) ** Three == #Peano(-8))
+assert((MinusTwo as any Integer.Type) ** Two == Four)
+
+// MARK: - Monus (truncated subtraction)
+
+assert(Five .- Three == Two)
+assert(Three .- Five == Zip)
+assert(Three .- Zip == Three)
+assert(Zip .- Five == Zip)
+assert(Four .- Four == Zip)
+
+// MARK: - Division and modulo
+
+assert(Six / Two == Three)
+assert(Six / Four == One)
+assert(Six % Four == Two)
+assert(Five % Three == Two)
+assert(Four / Two == Two)
+assert(Five / One == Five)
+assert(Zip / Three == Zip)
+
+// MARK: - Factorial
+
+assert(factorial(Zip) == One)
+assert(factorial(One) == One)
+assert(factorial(Three) == Six)
+assert(factorial(Four) == #Peano(24))
+
+// MARK: - Fibonacci
+
+assert(fibonacci(Zip) == Zip)
+assert(fibonacci(One) == One)
+assert(fibonacci(Two) == One)
+assert(fibonacci(Three) == Two)
+assert(fibonacci(Six) == #Peano(8))
+
+// MARK: - GCD
+
+assert(gcd(Six, Four) == Two)
+assert(gcd(Six, Three) == Three)
+assert(gcd(Five, Three) == One)
+assert(gcd(Four, Six) == Two)
+assert(gcd(Six, Zero.self) == Six)
+
 // MARK: - Compile-time type equality assertions (verified at build time)
 
 assertEqual(#PeanoType(0), #Peano(0))
@@ -128,6 +185,13 @@ assertEqual(#PeanoType(2 * 3 - 1), #Peano(5))
 assertEqual(#PeanoType(3 - 5), #Peano(-2))
 assertEqual(#PeanoType(0 - 2), #Peano(-2))
 assertEqual(#PeanoType(1 * 1), #Peano(1))
+assertEqual(#PeanoType(2 ** 3), #Peano(8))
+assertEqual(#PeanoType(5 .- 3), #Peano(2))
+assertEqual(#PeanoType(6 / 2), #Peano(3))
+assertEqual(#PeanoType(6 % 4), #Peano(2))
+assertEqual(#PeanoType(factorial(4)), #Peano(24))
+assertEqual(#PeanoType(fibonacci(6)), #Peano(8))
+assertEqual(#PeanoType(gcd(6, 4)), #Peano(2))
 
 // MARK: - Compile-time assertions (verified at macro expansion time)
 
@@ -142,3 +206,11 @@ assertEqual(#PeanoType(1 * 1), #Peano(1))
 #PeanoAssert(0 <= 0)
 #PeanoAssert(3 >= 2)
 #PeanoAssert(5 != 3)
+#PeanoAssert(2 ** 3 == 8)
+#PeanoAssert(5 .- 3 == 2)
+#PeanoAssert(3 .- 5 == 0)
+#PeanoAssert(6 / 2 == 3)
+#PeanoAssert(6 % 4 == 2)
+#PeanoAssert(factorial(3) == 6)
+#PeanoAssert(fibonacci(6) == 8)
+#PeanoAssert(gcd(6, 4) == 2)

--- a/Sources/PeanoNumbersMacros/Diagnostics.swift
+++ b/Sources/PeanoNumbersMacros/Diagnostics.swift
@@ -7,7 +7,7 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case expectedExpression = "#PeanoType requires an arithmetic expression"
     case unsupportedExpression = "Unsupported expression in Peano arithmetic"
     case unsupportedOperator = "Unsupported operator in Peano arithmetic"
-    case unsupportedFunction = "Unsupported function in Peano arithmetic (supported: negate)"
+    case unsupportedFunction = "Unsupported function in Peano arithmetic (supported: negate, factorial, fibonacci, gcd)"
     case expectedComparison = "#PeanoAssert requires a comparison expression (==, !=, <, >, <=, >=)"
     case unsupportedComparison = "Unsupported comparison operator"
 

--- a/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
@@ -117,5 +117,74 @@ final class PeanoAssertMacroTests: XCTestCase {
         )
     }
 
+    // MARK: - Arithmetic extension assertions
+
+    func testExponentiationPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(2 ** 3 == 8)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testMonusPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(5 .- 3 == 2)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testDivisionPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(6 / 2 == 3)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testModuloPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(6 % 4 == 2)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testFactorialPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(factorial(3) == 6)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testFibonacciPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(fibonacci(6) == 8)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testGcdPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(gcd(6, 4) == 2)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testExponentiationFails() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(2 ** 3 == 9)",
+            expandedSource: "#PeanoAssert(2 ** 3 == 9)",
+            diagnostics: [
+                DiagnosticSpec(message: "Peano assertion failed: 2 ** 3 is 8, not 9", line: 1, column: 1),
+            ],
+            macros: peanoAssertMacros
+        )
+    }
+
     #endif
 }

--- a/Tests/PeanoNumbersMacrosTests/PeanoTypeMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/PeanoTypeMacroTests.swift
@@ -86,5 +86,77 @@ final class PeanoTypeMacroTests: XCTestCase {
         )
     }
 
+    func testExponentiation() throws {
+        // 2 ** 3 = 8
+        assertMacroExpansion(
+            "#PeanoType(2 ** 3)",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testMonus() throws {
+        // 5 .- 3 = 2
+        assertMacroExpansion(
+            "#PeanoType(5 .- 3)",
+            expandedSource: "AddOne<AddOne<Zero>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testMonusClampsToZero() throws {
+        // 3 .- 5 = 0
+        assertMacroExpansion(
+            "#PeanoType(3 .- 5)",
+            expandedSource: "Zero.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testDivision() throws {
+        // 6 / 2 = 3
+        assertMacroExpansion(
+            "#PeanoType(6 / 2)",
+            expandedSource: "AddOne<AddOne<AddOne<Zero>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testModulo() throws {
+        // 6 % 4 = 2
+        assertMacroExpansion(
+            "#PeanoType(6 % 4)",
+            expandedSource: "AddOne<AddOne<Zero>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testFactorial() throws {
+        // factorial(4) = 24
+        assertMacroExpansion(
+            "#PeanoType(factorial(4))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>>>>>>>>>>>>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testFibonacci() throws {
+        // fibonacci(6) = 8
+        assertMacroExpansion(
+            "#PeanoType(fibonacci(6))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testGcd() throws {
+        // gcd(6, 4) = 2
+        assertMacroExpansion(
+            "#PeanoType(gcd(6, 4))",
+            expandedSource: "AddOne<AddOne<Zero>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
     #endif
 }

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -250,3 +250,102 @@ assert(!(Zip <= MinusOne))
 assert(Zip >= MinusOne)
 assert(MinusOne >= MinusOne)
 assert(!(MinusOne >= Zip))
+
+// MARK: - Exponentiation (right-hand recursion on exponent)
+
+infix operator ** : MultiplicationPrecedence
+
+func **(base: any Natural.Type, exp: any Natural.Type) -> any Natural.Type {
+    if exp == Zero.self { return AddOne<Zero>.self }
+    return (base ** (exp.predecessor as! any Natural.Type)) * base
+}
+
+func **(base: any Integer.Type, exp: any Natural.Type) -> any Integer.Type {
+    if exp == Zero.self { return AddOne<Zero>.self }
+    return (base ** (exp.predecessor as! any Natural.Type)) * base
+}
+
+assert(Two ** Three == AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>.self)
+assert(Three ** Two == AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>>.self)
+assert(Two ** Zip == One)
+assert(Zip ** Five == Zip)
+assert(One ** Six == One)
+
+// MARK: - Monus (truncated subtraction)
+
+infix operator .- : AdditionPrecedence
+
+func .-(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
+    if rhs == Zero.self { return lhs }
+    if lhs == Zero.self { return Zero.self }
+    return (lhs.predecessor as! any Natural.Type) .- (rhs.predecessor as! any Natural.Type)
+}
+
+assert(Five .- Three == Two)
+assert(Three .- Five == Zip)
+assert(Three .- Zip == Three)
+assert(Zip .- Five == Zip)
+assert(Four .- Four == Zip)
+
+// MARK: - Division and modulo
+
+func divmod(_ a: any Natural.Type, _ b: any Natural.Type) -> (any Natural.Type, any Natural.Type) {
+    if a < b { return (Zero.self, a) }
+    let (q, r) = divmod(a .- b, b)
+    return (q + AddOne<Zero>.self, r)
+}
+
+func /(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
+    divmod(lhs, rhs).0
+}
+
+func %(lhs: any Natural.Type, rhs: any Natural.Type) -> any Natural.Type {
+    divmod(lhs, rhs).1
+}
+
+assert(Six / Two == Three)
+assert(Six / Four == One)
+assert(Six % Four == Two)
+assert(Five % Three == Two)
+assert(Four / Two == Two)
+assert(Five / One == Five)
+assert(Zip / Three == Zip)
+
+// MARK: - Factorial
+
+func factorial(_ n: any Natural.Type) -> any Natural.Type {
+    if n == Zero.self { return AddOne<Zero>.self }
+    return n * factorial(n.predecessor as! any Natural.Type)
+}
+
+assert(factorial(Zip) == One)
+assert(factorial(One) == One)
+assert(factorial(Three) == Six)
+
+// MARK: - Fibonacci
+
+func fibonacci(_ n: any Natural.Type) -> any Natural.Type {
+    func helper(_ n: any Natural.Type, _ a: any Natural.Type, _ b: any Natural.Type) -> any Natural.Type {
+        if n == Zero.self { return a }
+        return helper(n.predecessor as! any Natural.Type, b, a + b)
+    }
+    return helper(n, Zero.self, AddOne<Zero>.self)
+}
+
+assert(fibonacci(Zip) == Zip)
+assert(fibonacci(One) == One)
+assert(fibonacci(Two) == One)
+assert(fibonacci(Three) == Two)
+
+// MARK: - GCD
+
+func gcd(_ a: any Natural.Type, _ b: any Natural.Type) -> any Natural.Type {
+    if b == Zero.self { return a }
+    return gcd(b, a % b)
+}
+
+assert(gcd(Six, Four) == Two)
+assert(gcd(Six, Three) == Three)
+assert(gcd(Five, Three) == One)
+assert(gcd(Four, Six) == Two)
+assert(gcd(Six, Zero.self) == Six)


### PR DESCRIPTION
## Summary

- Add exponentiation (`**`), monus (`.-`), division (`/`), modulo (`%`), `factorial()`, `fibonacci()`, `gcd()` as Peano metatype operations
- Add Int overloads to enable use in macro expressions
- Extend macro evaluator to handle all new operators and functions
- Add 16 new macro expansion tests (39 total)
- Update Xcode standalone target, README, and CLAUDE.md

Closes #9

## Test plan

- [x] `swift build` compiles without errors
- [x] `swift run PeanoNumbersClient` -- all runtime assertions pass
- [x] `swift test` -- all 39 macro expansion tests pass
- [x] `xcodebuild` -- Xcode standalone target builds