### PR TITLE
Add hyperoperation, Ackermann, and Church encoding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,14 @@ type-level-natural-numbers/main.swift    -- Xcode target entry point
 Sources/
   PeanoNumbers/                          -- library: types, operators, macro declarations
     PeanoTypes.swift                     -- protocols, Zero, AddOne, SubOne, operators, assertEqual
+    ChurchNumerals.swift                 -- Church numeral encoding (ChurchNumeral, ChurchZero, ChurchSucc, ChurchAdd, ChurchMul)
     Macros.swift                         -- @freestanding macro declarations
   PeanoNumbersMacros/                    -- .macro target: compiler plugin
     Plugin.swift                         -- CompilerPlugin entry point
     PeanoMacro.swift                     -- #Peano(n) implementation
     PeanoTypeMacro.swift                 -- #PeanoType(expr) implementation
     PeanoAssertMacro.swift               -- #PeanoAssert(expr) implementation
+    ChurchMacro.swift                    -- #Church(n) implementation
     ExpressionEvaluator.swift            -- shared arithmetic evaluator
     Diagnostics.swift                    -- PeanoDiagnostic enum
   PeanoNumbersClient/                    -- SPM executable: exercises everything
@@ -28,6 +30,7 @@ Tests/
     PeanoMacroTests.swift
     PeanoTypeMacroTests.swift
     PeanoAssertMacroTests.swift
+    ChurchMacroTests.swift
 ```
 
 ## Building and testing
@@ -72,3 +75,4 @@ The Xcode target is self-contained -- it does not depend on the SPM package. It 
 - `worktree-macros` -- extends integer-extension with Swift macros (`#Peano`, `#PeanoType`, `#PeanoAssert`) for compile-time arithmetic.
 - `worktree-simplify-protocols` -- extends macros: simplifies to 3 protocols, switches to right-hand recursion, adds `<=`/`>=`.
 - `worktree-arithmetic-extensions` -- extends simplify-protocols: adds exponentiation, monus, division/modulo, factorial, fibonacci, GCD; extends macro evaluator.
+- `worktree-advanced-extensions` -- extends arithmetic-extensions: adds hyperoperation, Ackermann function, Church numeral encoding with `#Church` macro.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,57 @@ gcd(a, 0) = a
 gcd(a, b) = gcd(b, a % b)
 ```
 
+### Hyperoperation (`hyperop`)
+
+The hyperoperation sequence generalizes successor, addition, multiplication, and exponentiation into a single recursive function:
+
+```
+H(0, a, b)       = S(b)          (successor)
+H(1, a, b)       = a + b         (addition)
+H(2, a, b)       = a * b         (multiplication)
+H(3, a, b)       = a ** b        (exponentiation)
+H(4, a, b)       = a ↑↑ b        (tetration)
+
+H(S(n), a, 0)    = identity(n)   -- a for n=0, 0 for n=1, 1 for n>=2
+H(S(n), a, S(b)) = H(n, a, H(S(n), a, b))
+```
+
+Natural-only by definition.
+
+### Ackermann function (`ackermann`)
+
+A total computable function that grows faster than any primitive recursive function:
+
+```
+A(0, n)       = S(n)
+A(S(m), 0)    = A(m, 1)
+A(S(m), S(n)) = A(m, A(S(m), n))
+```
+
+Natural-only by definition. Only small inputs are practical (the function grows extremely fast).
+
+### Church numerals
+
+A second encoding strategy alongside Peano types. Where Peano types encode the *structure* of a number (nested successors), Church numerals encode the *behavior* (function application count): `church(n)(f)(x) = f^n(x)`.
+
+```swift
+protocol ChurchNumeral {
+    static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T
+}
+
+enum ChurchZero: ChurchNumeral { ... }   // applies f zero times
+enum ChurchSucc<N: ChurchNumeral>: ChurchNumeral { ... }  // applies f one more time
+```
+
+Church arithmetic is defined at the type level:
+- `ChurchAdd<A, B>`: applies `f` a total of `a + b` times
+- `ChurchMul<A, B>`: applies `b(f)` a total of `a` times
+
+Convert to `Int` via `churchToInt(_:)`.
+
 ## Macros
 
-Three freestanding expression macros evaluate integer arithmetic at compile time. They are implemented as a Swift compiler plugin using SwiftSyntax.
+Four freestanding expression macros evaluate integer arithmetic at compile time. They are implemented as a Swift compiler plugin using SwiftSyntax.
 
 ### `#Peano(n)` -- integer literal to Peano metatype
 
@@ -173,7 +221,7 @@ Converts an integer literal to its Peano type representation:
 
 ### `#PeanoType(expr)` -- compile-time arithmetic
 
-Evaluates an arithmetic expression at macro expansion time and emits the concrete Peano type. Supports `+`, `-`, `*`, `**`, `.-`, `/`, `%`, `negate()`, `factorial()`, `fibonacci()`, `gcd()`:
+Evaluates an arithmetic expression at macro expansion time and emits the concrete Peano type. Supports `+`, `-`, `*`, `**`, `.-`, `/`, `%`, `negate()`, `factorial()`, `fibonacci()`, `gcd()`, `hyperop()`, `ackermann()`:
 
 ```swift
 #PeanoType(2 + 3)       // expands to: AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>.self
@@ -199,6 +247,15 @@ Evaluates a comparison at macro expansion time. Passing assertions expand to `()
 
 Supports `==`, `!=`, `<`, `>`, `<=`, `>=`.
 
+### `#Church(n)` -- integer literal to Church numeral type
+
+Converts a nonnegative integer literal to its Church numeral type representation:
+
+```swift
+#Church(0)  // expands to: ChurchZero.self
+#Church(3)  // expands to: ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>.self
+```
+
 ## Examples
 
 ```swift
@@ -213,10 +270,21 @@ assert(factorial(Three) == #Peano(6))
 assert(fibonacci(Three) == Two)
 assert(gcd(#Peano(6) as! any Natural.Type, #Peano(4) as! any Natural.Type) == Two)
 
+// Hyperoperations and Ackermann
+assert(hyperop(Three, Two, Three) == #Peano(8))   // H(3,2,3) = 2^3 = 8
+assert(ackermann(Two, Two) == #Peano(7))           // A(2,2) = 7
+
+// Church numerals
+let c3 = ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>.self
+assert(churchToInt(c3) == 3)
+assert(churchToInt(#Church(5)) == 5)
+
 // Compile-time assertions
 #PeanoAssert(2 ** 3 == 8)
 #PeanoAssert(factorial(4) == 24)
 #PeanoAssert(gcd(6, 4) == 2)
+#PeanoAssert(hyperop(3, 2, 3) == 8)
+#PeanoAssert(ackermann(2, 2) == 7)
 assertEqual(#PeanoType(fibonacci(6)), #Peano(8))
 ```
 

--- a/Sources/PeanoNumbers/ChurchNumerals.swift
+++ b/Sources/PeanoNumbers/ChurchNumerals.swift
@@ -1,0 +1,51 @@
+// MARK: - Church numeral protocol
+
+/// A Church numeral encodes a natural number as a function that applies
+/// its argument n times: `church(n)(f)(x) = f^n(x)`.
+///
+/// This is a second encoding strategy alongside Peano types. Where Peano
+/// types encode the *structure* of a number (nested successors), Church
+/// numerals encode the *behavior* (function application count).
+public protocol ChurchNumeral {
+    /// Apply a function `n` times to a value.
+    static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T
+}
+
+// MARK: - Church types
+
+/// Church encoding of zero: applies `f` zero times, returning `x` unchanged.
+public enum ChurchZero: ChurchNumeral {
+    public static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T { x }
+}
+
+/// Church encoding of the successor: applies `f` one more time than `N`.
+public enum ChurchSucc<N: ChurchNumeral>: ChurchNumeral {
+    public static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T {
+        f(N.apply(f, to: x))
+    }
+}
+
+// MARK: - Church arithmetic (type-level)
+
+/// Church addition: `(a + b)(f)(x) = a(f)(b(f)(x))`.
+/// Applies `f` a total of `a + b` times by composing the two Church numerals.
+public enum ChurchAdd<A: ChurchNumeral, B: ChurchNumeral>: ChurchNumeral {
+    public static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T {
+        A.apply(f, to: B.apply(f, to: x))
+    }
+}
+
+/// Church multiplication: `(a * b)(f)(x) = a(b(f))(x)`.
+/// Applies `b(f)` (which applies `f` b times) a total of `a` times.
+public enum ChurchMul<A: ChurchNumeral, B: ChurchNumeral>: ChurchNumeral {
+    public static func apply<T>(_ f: @escaping (T) -> T, to x: T) -> T {
+        A.apply({ B.apply(f, to: $0) }, to: x)
+    }
+}
+
+// MARK: - Church conversion
+
+/// Converts a Church numeral type to its integer value by applying `{ $0 + 1 }` to `0`.
+public func churchToInt<N: ChurchNumeral>(_: N.Type) -> Int {
+    N.apply({ $0 + 1 }, to: 0)
+}

--- a/Sources/PeanoNumbers/Macros.swift
+++ b/Sources/PeanoNumbers/Macros.swift
@@ -6,3 +6,6 @@ public macro PeanoType(_ expr: Any) -> any Integer.Type = #externalMacro(module:
 
 @freestanding(expression)
 public macro PeanoAssert(_ expr: Any) = #externalMacro(module: "PeanoNumbersMacros", type: "PeanoAssertMacro")
+
+@freestanding(expression)
+public macro Church(_ value: Int) -> any ChurchNumeral.Type = #externalMacro(module: "PeanoNumbersMacros", type: "ChurchMacro")

--- a/Sources/PeanoNumbers/PeanoTypes.swift
+++ b/Sources/PeanoNumbers/PeanoTypes.swift
@@ -250,6 +250,67 @@ public func gcd(_ a: any Natural.Type, _ b: any Natural.Type) -> any Natural.Typ
     return gcd(b, a % b)
 }
 
+// MARK: - Hyperoperation
+
+/// Int hyperoperation (enables `hyperop()` in macro expressions like `#PeanoType(hyperop(3, 2, 3))`).
+public func hyperop(_ n: Int, _ a: Int, _ b: Int) -> Int {
+    if n == 0 { return b + 1 }                        // H(0, a, b) = S(b)
+    if n == 1 && b == 0 { return a }                   // H(1, a, 0) = a
+    if n == 2 && b == 0 { return 0 }                   // H(2, a, 0) = 0
+    if b == 0 { return 1 }                             // H(n>=3, a, 0) = 1
+    return hyperop(n - 1, a, hyperop(n, a, b - 1))    // H(S(n), a, S(b)) = H(n, a, H(S(n), a, b))
+}
+
+/// Hyperoperation `H(n, a, b)` generalizing successor, addition, multiplication, exponentiation, and beyond.
+///
+/// ```
+/// H(0, a, b) = S(b)          (successor)
+/// H(1, a, b) = a + b         (addition)
+/// H(2, a, b) = a * b         (multiplication)
+/// H(3, a, b) = a ** b        (exponentiation)
+/// H(4, a, b) = a ↑↑ b        (tetration)
+/// ```
+///
+/// Recursive definition:
+/// ```
+/// H(0, a, b)       = S(b)
+/// H(S(n), a, 0)    = identity(n)     -- a for n=0, 0 for n=1, 1 for n>=2
+/// H(S(n), a, S(b)) = H(n, a, H(S(n), a, b))
+/// ```
+public func hyperop(_ n: any Natural.Type, _ a: any Natural.Type, _ b: any Natural.Type) -> any Natural.Type {
+    if n == Zero.self { return b.successor }                                      // H(0, a, b) = S(b)
+    let nPred = n.predecessor as! any Natural.Type
+    if b == Zero.self {
+        if nPred == Zero.self { return a }                                        // H(1, a, 0) = a
+        if nPred == AddOne<Zero>.self { return Zero.self }                        // H(2, a, 0) = 0
+        return AddOne<Zero>.self                                                  // H(n>=3, a, 0) = 1
+    }
+    return hyperop(nPred, a, hyperop(n, a, b.predecessor as! any Natural.Type))  // H(S(n), a, S(b)) = H(n, a, H(S(n), a, b))
+}
+
+// MARK: - Ackermann function
+
+/// Int Ackermann function (enables `ackermann()` in macro expressions like `#PeanoType(ackermann(2, 2))`).
+public func ackermann(_ m: Int, _ n: Int) -> Int {
+    if m == 0 { return n + 1 }
+    if n == 0 { return ackermann(m - 1, 1) }
+    return ackermann(m - 1, ackermann(m, n - 1))
+}
+
+/// Ackermann function: a total computable function that grows faster than any primitive recursive function.
+///
+/// ```
+/// A(0, n)    = S(n)
+/// A(S(m), 0) = A(m, 1)
+/// A(S(m), S(n)) = A(m, A(S(m), n))
+/// ```
+public func ackermann(_ m: any Natural.Type, _ n: any Natural.Type) -> any Natural.Type {
+    if m == Zero.self { return n.successor }                                      // A(0, n) = S(n)
+    let mPred = m.predecessor as! any Natural.Type
+    if n == Zero.self { return ackermann(mPred, AddOne<Zero>.self) }              // A(S(m), 0) = A(m, 1)
+    return ackermann(mPred, ackermann(m, n.predecessor as! any Natural.Type))    // A(S(m), S(n)) = A(m, A(S(m), n))
+}
+
 // MARK: - Type equality assertions
 
 /// Compile-time type equality assertion. Compiles only when both arguments

--- a/Sources/PeanoNumbersClient/main.swift
+++ b/Sources/PeanoNumbersClient/main.swift
@@ -176,6 +176,47 @@ assert(gcd(Five, Three) == One)
 assert(gcd(Four, Six) == Two)
 assert(gcd(Six, Zero.self) == Six)
 
+// MARK: - Hyperoperations
+
+assert(hyperop(Zip, Two, Three) == Four)              // H(0, a, b) = S(b)
+assert(hyperop(One, Two, Three) == Five)               // H(1, a, b) = a + b
+assert(hyperop(Two, Two, Three) == Six)                // H(2, a, b) = a * b
+assert(hyperop(Three, Two, Three) == #Peano(8))        // H(3, a, b) = a ** b
+assert(hyperop(One, Zip, Zip) == Zip)                  // H(1, 0, 0) = 0
+assert(hyperop(Two, Three, Zip) == Zip)                // H(2, a, 0) = 0
+assert(hyperop(Three, Two, Zip) == One)                // H(3, a, 0) = 1
+
+// MARK: - Ackermann function
+
+assert(ackermann(Zip, Zip) == One)                     // A(0, 0) = 1
+assert(ackermann(Zip, Three) == Four)                  // A(0, n) = n + 1
+assert(ackermann(One, One) == Three)                   // A(1, 1) = 3
+assert(ackermann(Two, Two) == #Peano(7))               // A(2, 2) = 7
+assert(ackermann(Three, One) == #Peano(13))            // A(3, 1) = 13
+
+// MARK: - Church numerals
+
+let c0 = ChurchZero.self
+let c1 = ChurchSucc<ChurchZero>.self
+let c2 = ChurchSucc<ChurchSucc<ChurchZero>>.self
+let c3 = ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>.self
+
+assert(churchToInt(c0) == 0)
+assert(churchToInt(c1) == 1)
+assert(churchToInt(c2) == 2)
+assert(churchToInt(c3) == 3)
+
+// Church addition: 2 + 3 = 5
+assert(churchToInt(ChurchAdd<ChurchSucc<ChurchSucc<ChurchZero>>, ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>>.self) == 5)
+
+// Church multiplication: 2 * 3 = 6
+assert(churchToInt(ChurchMul<ChurchSucc<ChurchSucc<ChurchZero>>, ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>>.self) == 6)
+
+// Church macro
+assert(churchToInt(#Church(0)) == 0)
+assert(churchToInt(#Church(3)) == 3)
+assert(churchToInt(#Church(5)) == 5)
+
 // MARK: - Compile-time type equality assertions (verified at build time)
 
 assertEqual(#PeanoType(0), #Peano(0))
@@ -192,6 +233,8 @@ assertEqual(#PeanoType(6 % 4), #Peano(2))
 assertEqual(#PeanoType(factorial(4)), #Peano(24))
 assertEqual(#PeanoType(fibonacci(6)), #Peano(8))
 assertEqual(#PeanoType(gcd(6, 4)), #Peano(2))
+assertEqual(#PeanoType(hyperop(3, 2, 3)), #Peano(8))
+assertEqual(#PeanoType(ackermann(2, 2)), #Peano(7))
 
 // MARK: - Compile-time assertions (verified at macro expansion time)
 
@@ -214,3 +257,7 @@ assertEqual(#PeanoType(gcd(6, 4)), #Peano(2))
 #PeanoAssert(factorial(3) == 6)
 #PeanoAssert(fibonacci(6) == 8)
 #PeanoAssert(gcd(6, 4) == 2)
+#PeanoAssert(hyperop(3, 2, 3) == 8)
+#PeanoAssert(hyperop(1, 2, 3) == 5)
+#PeanoAssert(ackermann(2, 2) == 7)
+#PeanoAssert(ackermann(0, 3) == 4)

--- a/Sources/PeanoNumbersMacros/ChurchMacro.swift
+++ b/Sources/PeanoNumbersMacros/ChurchMacro.swift
@@ -1,0 +1,38 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// `#Church(n)` -- converts a nonnegative integer literal to its Church numeral type.
+///
+/// ```swift
+/// #Church(0)  // expands to: ChurchZero.self
+/// #Church(3)  // expands to: ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>.self
+/// ```
+public struct ChurchMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        guard let argument = node.arguments.first?.expression else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.missingArgument)
+            ])
+        }
+
+        guard let literal = argument.as(IntegerLiteralExprSyntax.self),
+              let value = Int(literal.literal.text) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(argument), message: PeanoDiagnostic.expectedIntegerLiteral)
+            ])
+        }
+
+        guard value >= 0 else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(argument), message: PeanoDiagnostic.churchRequiresNonnegative)
+            ])
+        }
+
+        let typeName = churchTypeName(for: value)
+        return "\(raw: typeName).self"
+    }
+}

--- a/Sources/PeanoNumbersMacros/Diagnostics.swift
+++ b/Sources/PeanoNumbersMacros/Diagnostics.swift
@@ -7,9 +7,10 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case expectedExpression = "#PeanoType requires an arithmetic expression"
     case unsupportedExpression = "Unsupported expression in Peano arithmetic"
     case unsupportedOperator = "Unsupported operator in Peano arithmetic"
-    case unsupportedFunction = "Unsupported function in Peano arithmetic (supported: negate, factorial, fibonacci, gcd)"
+    case unsupportedFunction = "Unsupported function in Peano arithmetic (supported: negate, factorial, fibonacci, gcd, hyperop, ackermann)"
     case expectedComparison = "#PeanoAssert requires a comparison expression (==, !=, <, >, <=, >=)"
     case unsupportedComparison = "Unsupported comparison operator"
+    case churchRequiresNonnegative = "#Church requires a nonnegative integer literal (e.g. #Church(3))"
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "PeanoNumbersMacros", id: rawValue) }

--- a/Sources/PeanoNumbersMacros/ExpressionEvaluator.swift
+++ b/Sources/PeanoNumbersMacros/ExpressionEvaluator.swift
@@ -8,6 +8,11 @@ func peanoTypeName(for n: Int) -> String {
     return String(repeating: "SubOne<", count: -n) + "Zero" + String(repeating: ">", count: -n)
 }
 
+func churchTypeName(for n: Int) -> String {
+    if n <= 0 { return "ChurchZero" }
+    return String(repeating: "ChurchSucc<", count: n) + "ChurchZero" + String(repeating: ">", count: n)
+}
+
 enum EvaluationError: Error {
     case unsupportedExpression(ExprSyntax)
     case unsupportedOperator(String)
@@ -40,10 +45,24 @@ private func factorialInt(_ n: Int) -> Int {
     (1...max(1, n)).reduce(1, *)
 }
 
+private func hyperopInt(_ n: Int, _ a: Int, _ b: Int) -> Int {
+    if n == 0 { return b + 1 }
+    if n == 1 && b == 0 { return a }
+    if n == 2 && b == 0 { return 0 }
+    if b == 0 { return 1 }
+    return hyperopInt(n - 1, a, hyperopInt(n, a, b - 1))
+}
+
+private func ackermannInt(_ m: Int, _ n: Int) -> Int {
+    if m == 0 { return n + 1 }
+    if n == 0 { return ackermannInt(m - 1, 1) }
+    return ackermannInt(m - 1, ackermannInt(m, n - 1))
+}
+
 /// Evaluates a SwiftSyntax arithmetic expression to an Int.
 ///
 /// Supports integer literals, prefix minus, binary operators (+, -, *, **, .-, /, %),
-/// function calls (negate, factorial, fibonacci, gcd), and parentheses.
+/// function calls (negate, factorial, fibonacci, gcd, hyperop, ackermann), and parentheses.
 /// The Swift compiler folds operator precedence before macro expansion, so
 /// `2 + 3 * 4` arrives already structured as `2 + (3 * 4)`.
 func evaluateExpression(_ expr: ExprSyntax) throws -> Int {
@@ -88,6 +107,8 @@ func evaluateExpression(_ expr: ExprSyntax) throws -> Int {
         case ("factorial", 1): return factorialInt(args[0])
         case ("fibonacci", 1): return fibonacciInt(args[0])
         case ("gcd", 2):       return gcdInt(args[0], args[1])
+        case ("hyperop", 3):   return hyperopInt(args[0], args[1], args[2])
+        case ("ackermann", 2): return ackermannInt(args[0], args[1])
         default: throw EvaluationError.unsupportedFunction(name)
         }
     }

--- a/Sources/PeanoNumbersMacros/Plugin.swift
+++ b/Sources/PeanoNumbersMacros/Plugin.swift
@@ -7,5 +7,6 @@ struct PeanoNumbersPlugin: CompilerPlugin {
         PeanoMacro.self,
         PeanoTypeMacro.self,
         PeanoAssertMacro.self,
+        ChurchMacro.self,
     ]
 }

--- a/Tests/PeanoNumbersMacrosTests/ChurchMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/ChurchMacroTests.swift
@@ -1,0 +1,41 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(PeanoNumbersMacros)
+import PeanoNumbersMacros
+
+nonisolated(unsafe) let churchMacros: [String: Macro.Type] = [
+    "Church": ChurchMacro.self,
+]
+#endif
+
+final class ChurchMacroTests: XCTestCase {
+    #if canImport(PeanoNumbersMacros)
+
+    func testZero() throws {
+        assertMacroExpansion(
+            "#Church(0)",
+            expandedSource: "ChurchZero.self",
+            macros: churchMacros
+        )
+    }
+
+    func testOne() throws {
+        assertMacroExpansion(
+            "#Church(1)",
+            expandedSource: "ChurchSucc<ChurchZero>.self",
+            macros: churchMacros
+        )
+    }
+
+    func testThree() throws {
+        assertMacroExpansion(
+            "#Church(3)",
+            expandedSource: "ChurchSucc<ChurchSucc<ChurchSucc<ChurchZero>>>.self",
+            macros: churchMacros
+        )
+    }
+
+    #endif
+}

--- a/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
@@ -175,6 +175,33 @@ final class PeanoAssertMacroTests: XCTestCase {
         )
     }
 
+    func testHyperopPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(hyperop(3, 2, 3) == 8)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testAckermannPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(ackermann(2, 2) == 7)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testHyperopFails() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(hyperop(1, 2, 3) == 6)",
+            expandedSource: "#PeanoAssert(hyperop(1, 2, 3) == 6)",
+            diagnostics: [
+                DiagnosticSpec(message: "Peano assertion failed: hyperop(1, 2, 3) is 5, not 6", line: 1, column: 1),
+            ],
+            macros: peanoAssertMacros
+        )
+    }
+
     func testExponentiationFails() throws {
         assertMacroExpansion(
             "#PeanoAssert(2 ** 3 == 9)",

--- a/Tests/PeanoNumbersMacrosTests/PeanoTypeMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/PeanoTypeMacroTests.swift
@@ -158,5 +158,59 @@ final class PeanoTypeMacroTests: XCTestCase {
         )
     }
 
+    func testHyperopSuccessor() throws {
+        // hyperop(0, 2, 3) = S(3) = 4
+        assertMacroExpansion(
+            "#PeanoType(hyperop(0, 2, 3))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<Zero>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testHyperopAddition() throws {
+        // hyperop(1, 2, 3) = 2 + 3 = 5
+        assertMacroExpansion(
+            "#PeanoType(hyperop(1, 2, 3))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testHyperopMultiplication() throws {
+        // hyperop(2, 2, 3) = 2 * 3 = 6
+        assertMacroExpansion(
+            "#PeanoType(hyperop(2, 2, 3))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testHyperopExponentiation() throws {
+        // hyperop(3, 2, 3) = 2 ** 3 = 8
+        assertMacroExpansion(
+            "#PeanoType(hyperop(3, 2, 3))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testAckermann() throws {
+        // ackermann(2, 2) = 7
+        assertMacroExpansion(
+            "#PeanoType(ackermann(2, 2))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
+    func testAckermannBaseCase() throws {
+        // ackermann(0, 3) = 4
+        assertMacroExpansion(
+            "#PeanoType(ackermann(0, 3))",
+            expandedSource: "AddOne<AddOne<AddOne<AddOne<Zero>>>>.self",
+            macros: peanoTypeMacros
+        )
+    }
+
     #endif
 }


### PR DESCRIPTION
## Summary

- Add hyperoperation `H(n, a, b)` generalizing successor, addition, multiplication, exponentiation, and beyond
- Add Ackermann function `A(m, n)`, a total computable function growing faster than any primitive recursive function
- Add Church numeral encoding (`ChurchNumeral`, `ChurchZero`, `ChurchSucc`, `ChurchAdd`, `ChurchMul`, `churchToInt`)
- Add `#Church(n)` macro for compile-time Church type generation
- Extend macro evaluator with `hyperop()` and `ackermann()` support

Closes #11

## Test plan

- [x] `swift build` compiles without errors
- [x] `swift run PeanoNumbersClient` -- all runtime assertions pass
- [x] `swift test` -- 51 tests pass (12 new)
- [x] `xcodebuild` -- Xcode target builds and runs