### PR TITLE
Add #Gaussian macro, sign-parameterized multiplication, and algebra evaluator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Sources/
   PeanoNumbers/                          -- library: types, operators, macro declarations
     PeanoTypes.swift                     -- protocols, Zero, AddOne, SubOne, operators, assertEqual
     ChurchNumerals.swift                 -- Church numeral encoding (ChurchNumeral, ChurchZero, ChurchSucc, ChurchAdd, ChurchMul)
-    CayleyDickson.swift                  -- Cayley-Dickson construction (Algebra, AlgebraValue, CayleyDickson, gaussian, quaternion)
+    CayleyDickson.swift                  -- Cayley-Dickson construction (Algebra, AlgebraValue, CayleyDickson, gaussian, quaternion, sign-parameterized multiply/norm)
     Macros.swift                         -- @freestanding macro declarations
   PeanoNumbersMacros/                    -- .macro target: compiler plugin
     Plugin.swift                         -- CompilerPlugin entry point
@@ -22,7 +22,8 @@ Sources/
     PeanoTypeMacro.swift                 -- #PeanoType(expr) implementation
     PeanoAssertMacro.swift               -- #PeanoAssert(expr) implementation
     ChurchMacro.swift                    -- #Church(n) implementation
-    ExpressionEvaluator.swift            -- shared arithmetic evaluator
+    GaussianMacro.swift                  -- #Gaussian(re, im) implementation
+    ExpressionEvaluator.swift            -- shared arithmetic/algebra evaluator (EvalValue, evaluateAlgebraExpression)
     Diagnostics.swift                    -- PeanoDiagnostic enum
   PeanoNumbersClient/                    -- SPM executable: exercises everything
     main.swift                           -- convenience bindings, runtime + compile-time assertions
@@ -32,6 +33,7 @@ Tests/
     PeanoTypeMacroTests.swift
     PeanoAssertMacroTests.swift
     ChurchMacroTests.swift
+    GaussianMacroTests.swift
 ```
 
 ## Building and testing
@@ -78,3 +80,4 @@ The Xcode target is self-contained -- it does not depend on the SPM package. It 
 - `worktree-arithmetic-extensions` -- extends simplify-protocols: adds exponentiation, monus, division/modulo, factorial, fibonacci, GCD; extends macro evaluator.
 - `worktree-advanced-extensions` -- extends arithmetic-extensions: adds hyperoperation, Ackermann function, Church numeral encoding with `#Church` macro.
 - `worktree-cayley-dickson` -- extends advanced-extensions: adds Cayley-Dickson construction (Algebra protocol, AlgebraValue, CayleyDickson type, Gaussian integers, quaternions).
+- `worktree-cayley-dickson-macros` -- extends cayley-dickson: adds `#Gaussian` macro, sign-parameterized multiplication/norm (split-complex, dual numbers), and Cayley-Dickson evaluator for `#PeanoAssert`.

--- a/Sources/PeanoNumbers/Macros.swift
+++ b/Sources/PeanoNumbers/Macros.swift
@@ -9,3 +9,6 @@ public macro PeanoAssert(_ expr: Any) = #externalMacro(module: "PeanoNumbersMacr
 
 @freestanding(expression)
 public macro Church(_ value: Int) -> any ChurchNumeral.Type = #externalMacro(module: "PeanoNumbersMacros", type: "ChurchMacro")
+
+@freestanding(expression)
+public macro Gaussian(_ re: Any, _ im: Any) -> AlgebraValue = #externalMacro(module: "PeanoNumbersMacros", type: "GaussianMacro")

--- a/Sources/PeanoNumbersClient/main.swift
+++ b/Sources/PeanoNumbersClient/main.swift
@@ -361,3 +361,47 @@ assert(norm(q1) == Thirty)
 // -- Scalar embeds into quaternion --
 
 assert(AlgebraValue.scalar(One) + q1 == quaternion(Two, Two, Three, Four))
+
+// MARK: - Sign-parameterized Cayley-Dickson
+
+// -- Split-complex: j² = +1 (not -1) --
+
+let splitJ = gaussian(Zip, One)
+assert(multiply(splitJ, splitJ, sign: .split) == gaussian(One, Zip))
+
+// -- Standard: i² = -1 (unchanged) --
+
+assert(multiply(splitJ, splitJ, sign: .standard) == gaussian(MinusOne, Zip))
+
+// -- Dual: ε² = 0 --
+
+assert(multiply(splitJ, splitJ, sign: .dual) == gaussian(Zip, Zip))
+
+// -- Split multiplication distributes: (1+j)(1+j) = 1 + j + j + j² = 2 + 2j --
+
+let onePlusJ = gaussian(One, One)
+assert(multiply(onePlusJ, onePlusJ, sign: .split) == gaussian(Two, Two))
+
+// -- Dual norm: N_dual(a + εb) = a² (imaginary contributes nothing) --
+
+assert(norm(onePlusJ, sign: .dual) == AlgebraValue.scalar(One))
+
+// -- Split norm: N_split(a + jb) = a² - b² --
+
+assert(norm(onePlusJ, sign: .split) == AlgebraValue.scalar(Zip))
+
+// -- Standard norm unchanged --
+
+assert(norm(onePlusJ, sign: .standard) == AlgebraValue.scalar(Two))
+
+// MARK: - #Gaussian macro
+
+assert(#Gaussian(1, 2) == gaussian(One, Two))
+assert(#Gaussian(0, 0) == gaussian(Zip, Zip))
+assert(#Gaussian(3, -1) == gaussian(Three, MinusOne))
+assert(#Gaussian(2 + 1, 3 * -1) == gaussian(Three, MinusThree))
+
+// Cayley-Dickson assertions via #PeanoAssert are verified in the test target
+// (the compiler type-checks macro arguments for operator precedence folding,
+// so `gaussian(1, 2)` with Int literals doesn't pass the type-checker --
+// use assertMacroExpansion in tests instead).

--- a/Sources/PeanoNumbersMacros/Diagnostics.swift
+++ b/Sources/PeanoNumbersMacros/Diagnostics.swift
@@ -11,6 +11,7 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case expectedComparison = "#PeanoAssert requires a comparison expression (==, !=, <, >, <=, >=)"
     case unsupportedComparison = "Unsupported comparison operator"
     case churchRequiresNonnegative = "#Church requires a nonnegative integer literal (e.g. #Church(3))"
+    case gaussianRequiresTwoArguments = "#Gaussian requires two integer expression arguments (e.g. #Gaussian(1, 2))"
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "PeanoNumbersMacros", id: rawValue) }

--- a/Sources/PeanoNumbersMacros/ExpressionEvaluator.swift
+++ b/Sources/PeanoNumbersMacros/ExpressionEvaluator.swift
@@ -65,51 +65,220 @@ private func ackermannInt(_ m: Int, _ n: Int) -> Int {
 /// function calls (negate, factorial, fibonacci, gcd, hyperop, ackermann), and parentheses.
 /// The Swift compiler folds operator precedence before macro expansion, so
 /// `2 + 3 * 4` arrives already structured as `2 + (3 * 4)`.
+///
+/// This is a convenience wrapper around `evaluateAlgebraExpression` that extracts an Int.
+/// For expressions that evaluate to Cayley-Dickson pairs, use `evaluateAlgebraExpression` directly.
 func evaluateExpression(_ expr: ExprSyntax) throws -> Int {
+    let result = try evaluateAlgebraExpression(expr)
+    guard case .integer(let value) = result else {
+        throw EvaluationError.unsupportedExpression(expr)
+    }
+    return value
+}
+
+/// Evaluates a comparison expression and returns (lhs value, rhs value, operator, result).
+func evaluateComparison(_ expr: ExprSyntax) throws -> (lhs: Int, rhs: Int, op: String, result: Bool) {
+    let algebra = try evaluateAlgebraComparison(expr)
+    guard case .integer(let lhs) = algebra.lhs,
+          case .integer(let rhs) = algebra.rhs else {
+        throw EvaluationError.expectedComparison(expr)
+    }
+    return (lhs, rhs, algebra.op, algebra.result)
+}
+
+// MARK: - EvalValue (algebra evaluator)
+
+/// Recursive value type for compile-time evaluation of Cayley-Dickson expressions.
+///
+/// Extends the evaluator beyond plain `Int` to handle Gaussian integers, quaternions, etc.
+/// - `.integer(n)`: a scalar (level 0)
+/// - `.pair(a, b)`: a Cayley-Dickson pair at level `depth(a) + 1`
+indirect enum EvalValue: Equatable {
+    case integer(Int)
+    case pair(EvalValue, EvalValue)
+}
+
+// MARK: - EvalValue helpers
+
+private func depthEval(_ v: EvalValue) -> Int {
+    switch v {
+    case .integer: return 0
+    case .pair(let a, _): return depthEval(a) + 1
+    }
+}
+
+private func zeroEval(ofDepth d: Int) -> EvalValue {
+    if d <= 0 { return .integer(0) }
+    let z = zeroEval(ofDepth: d - 1)
+    return .pair(z, z)
+}
+
+private func embedEval(_ v: EvalValue, toDepth d: Int) -> EvalValue {
+    let current = depthEval(v)
+    if current >= d { return v }
+    return embedEval(.pair(v, zeroEval(ofDepth: current)), toDepth: d)
+}
+
+// MARK: - EvalValue arithmetic
+
+private func addEval(_ lhs: EvalValue, _ rhs: EvalValue) -> EvalValue {
+    let d = max(depthEval(lhs), depthEval(rhs))
+    return addEvalSameDepth(embedEval(lhs, toDepth: d), embedEval(rhs, toDepth: d))
+}
+
+private func addEvalSameDepth(_ lhs: EvalValue, _ rhs: EvalValue) -> EvalValue {
+    switch (lhs, rhs) {
+    case (.integer(let a), .integer(let b)):
+        return .integer(a + b)
+    case (.pair(let a, let b), .pair(let c, let d)):
+        return .pair(addEvalSameDepth(a, c), addEvalSameDepth(b, d))
+    default:
+        fatalError("EvalValue depth mismatch")
+    }
+}
+
+private func negateEval(_ v: EvalValue) -> EvalValue {
+    switch v {
+    case .integer(let n): return .integer(-n)
+    case .pair(let a, let b): return .pair(negateEval(a), negateEval(b))
+    }
+}
+
+private func conjugateEval(_ v: EvalValue) -> EvalValue {
+    switch v {
+    case .integer: return v
+    case .pair(let re, let im): return .pair(conjugateEval(re), negateEval(im))
+    }
+}
+
+private func mulEval(_ lhs: EvalValue, _ rhs: EvalValue) -> EvalValue {
+    let d = max(depthEval(lhs), depthEval(rhs))
+    return mulEvalSameDepth(embedEval(lhs, toDepth: d), embedEval(rhs, toDepth: d))
+}
+
+private func mulEvalSameDepth(_ lhs: EvalValue, _ rhs: EvalValue) -> EvalValue {
+    switch (lhs, rhs) {
+    case (.integer(let a), .integer(let b)):
+        return .integer(a * b)
+    case (.pair(let a, let b), .pair(let c, let d)):
+        // Standard Cayley-Dickson: (a,b)*(c,d) = (ac - conj(d)*b, da + b*conj(c))
+        let ac = mulEvalSameDepth(a, c)
+        let conjD_b = mulEvalSameDepth(conjugateEval(d), b)
+        let da = mulEvalSameDepth(d, a)
+        let b_conjC = mulEvalSameDepth(b, conjugateEval(c))
+        return .pair(addEvalSameDepth(ac, negateEval(conjD_b)), addEvalSameDepth(da, b_conjC))
+    default:
+        fatalError("EvalValue depth mismatch")
+    }
+}
+
+private func normEval(_ v: EvalValue) -> EvalValue {
+    switch v {
+    case .integer(let n): return .integer(n * n)
+    case .pair(let re, let im):
+        return addEvalSameDepth(normEval(re), normEval(im))
+    }
+}
+
+/// Format an EvalValue for diagnostic messages.
+func formatEvalValue(_ v: EvalValue) -> String {
+    switch v {
+    case .integer(let n): return "\(n)"
+    case .pair(let a, let b): return "(\(formatEvalValue(a)), \(formatEvalValue(b)))"
+    }
+}
+
+// MARK: - Algebra expression evaluator
+
+/// Evaluates a SwiftSyntax expression to an EvalValue (integer or Cayley-Dickson pair).
+///
+/// Extends the scalar evaluator to handle `gaussian(a, b)`, `conjugate(expr)`, `norm(expr)`,
+/// and arithmetic on pairs via `+`, `-`, `*`.
+func evaluateAlgebraExpression(_ expr: ExprSyntax) throws -> EvalValue {
     // Integer literal: 42
     if let literal = expr.as(IntegerLiteralExprSyntax.self) {
         guard let value = Int(literal.literal.text) else {
             throw EvaluationError.unsupportedExpression(expr)
         }
-        return value
+        return .integer(value)
     }
 
     // Prefix minus: -3
     if let prefix = expr.as(PrefixOperatorExprSyntax.self),
        prefix.operator.text == "-" {
-        return -(try evaluateExpression(prefix.expression))
+        return negateEval(try evaluateAlgebraExpression(prefix.expression))
     }
 
-    // Infix operator: 2 + 3, 2 * 3, 2 - 3, 2 ** 3, 5 .- 3, 6 / 2, 6 % 4
+    // Infix operator: handles both scalar and pair arithmetic
     if let infix = expr.as(InfixOperatorExprSyntax.self),
        let op = infix.operator.as(BinaryOperatorExprSyntax.self) {
-        let lhs = try evaluateExpression(infix.leftOperand)
-        let rhs = try evaluateExpression(infix.rightOperand)
+        let lhs = try evaluateAlgebraExpression(infix.leftOperand)
+        let rhs = try evaluateAlgebraExpression(infix.rightOperand)
         switch op.operator.text {
-        case "+":  return lhs + rhs
-        case "-":  return lhs - rhs
-        case "*":  return lhs * rhs
-        case "**": return intPow(lhs, rhs)
-        case ".-": return max(lhs - rhs, 0)
-        case "/":  return lhs / rhs
-        case "%":  return lhs % rhs
+        case "+":  return addEval(lhs, rhs)
+        case "-":  return addEval(lhs, negateEval(rhs))
+        case "*":  return mulEval(lhs, rhs)
+        case "**":
+            guard case .integer(let base) = lhs, case .integer(let exp) = rhs else {
+                throw EvaluationError.unsupportedOperator(op.operator.text)
+            }
+            return .integer(intPow(base, exp))
+        case ".-":
+            guard case .integer(let l) = lhs, case .integer(let r) = rhs else {
+                throw EvaluationError.unsupportedOperator(op.operator.text)
+            }
+            return .integer(max(l - r, 0))
+        case "/":
+            guard case .integer(let l) = lhs, case .integer(let r) = rhs else {
+                throw EvaluationError.unsupportedOperator(op.operator.text)
+            }
+            return .integer(l / r)
+        case "%":
+            guard case .integer(let l) = lhs, case .integer(let r) = rhs else {
+                throw EvaluationError.unsupportedOperator(op.operator.text)
+            }
+            return .integer(l % r)
         default: throw EvaluationError.unsupportedOperator(op.operator.text)
         }
     }
 
-    // Function call: negate(x), factorial(x), fibonacci(x), gcd(a, b)
+    // Function call
     if let call = expr.as(FunctionCallExprSyntax.self),
        let callee = call.calledExpression.as(DeclReferenceExprSyntax.self) {
         let name = callee.baseName.text
-        let args = try call.arguments.map { try evaluateExpression($0.expression) }
-        switch (name, args.count) {
-        case ("negate", 1):    return -args[0]
-        case ("factorial", 1): return factorialInt(args[0])
-        case ("fibonacci", 1): return fibonacciInt(args[0])
-        case ("gcd", 2):       return gcdInt(args[0], args[1])
-        case ("hyperop", 3):   return hyperopInt(args[0], args[1], args[2])
-        case ("ackermann", 2): return ackermannInt(args[0], args[1])
-        default: throw EvaluationError.unsupportedFunction(name)
+
+        // Cayley-Dickson constructors and operations
+        switch name {
+        case "gaussian":
+            let args = try call.arguments.map { try evaluateAlgebraExpression($0.expression) }
+            guard args.count == 2 else { throw EvaluationError.unsupportedFunction(name) }
+            return .pair(args[0], args[1])
+        case "conjugate":
+            let args = try call.arguments.map { try evaluateAlgebraExpression($0.expression) }
+            guard args.count == 1 else { throw EvaluationError.unsupportedFunction(name) }
+            return conjugateEval(args[0])
+        case "norm":
+            let args = try call.arguments.map { try evaluateAlgebraExpression($0.expression) }
+            guard args.count == 1 else { throw EvaluationError.unsupportedFunction(name) }
+            return normEval(args[0])
+        default:
+            // Scalar-only functions
+            let args = try call.arguments.map { try evaluateAlgebraExpression($0.expression) }
+            let intArgs = try args.map { v -> Int in
+                guard case .integer(let n) = v else {
+                    throw EvaluationError.unsupportedFunction(name)
+                }
+                return n
+            }
+            switch (name, intArgs.count) {
+            case ("negate", 1):    return .integer(-intArgs[0])
+            case ("factorial", 1): return .integer(factorialInt(intArgs[0]))
+            case ("fibonacci", 1): return .integer(fibonacciInt(intArgs[0]))
+            case ("gcd", 2):       return .integer(gcdInt(intArgs[0], intArgs[1]))
+            case ("hyperop", 3):   return .integer(hyperopInt(intArgs[0], intArgs[1], intArgs[2]))
+            case ("ackermann", 2): return .integer(ackermannInt(intArgs[0], intArgs[1]))
+            default: throw EvaluationError.unsupportedFunction(name)
+            }
         }
     }
 
@@ -117,31 +286,41 @@ func evaluateExpression(_ expr: ExprSyntax) throws -> Int {
     if let tuple = expr.as(TupleExprSyntax.self),
        tuple.elements.count == 1,
        let element = tuple.elements.first {
-        return try evaluateExpression(element.expression)
+        return try evaluateAlgebraExpression(element.expression)
     }
 
     throw EvaluationError.unsupportedExpression(expr)
 }
 
-/// Evaluates a comparison expression and returns (lhs value, rhs value, operator, result).
-func evaluateComparison(_ expr: ExprSyntax) throws -> (lhs: Int, rhs: Int, op: String, result: Bool) {
+/// Evaluates a comparison expression on algebra values.
+/// Supports `==` and `!=` for pairs; scalar comparisons also support `<`, `>`, `<=`, `>=`.
+func evaluateAlgebraComparison(_ expr: ExprSyntax) throws
+    -> (lhs: EvalValue, rhs: EvalValue, op: String, result: Bool) {
     guard let infix = expr.as(InfixOperatorExprSyntax.self),
           let op = infix.operator.as(BinaryOperatorExprSyntax.self) else {
         throw EvaluationError.expectedComparison(expr)
     }
 
     let opText = op.operator.text
-    let lhs = try evaluateExpression(infix.leftOperand)
-    let rhs = try evaluateExpression(infix.rightOperand)
+    let lhs = try evaluateAlgebraExpression(infix.leftOperand)
+    let rhs = try evaluateAlgebraExpression(infix.rightOperand)
 
     let result: Bool
     switch opText {
     case "==": result = lhs == rhs
     case "!=": result = lhs != rhs
-    case "<":  result = lhs < rhs
-    case ">":  result = lhs > rhs
-    case "<=": result = lhs <= rhs
-    case ">=": result = lhs >= rhs
+    case "<", ">", "<=", ">=":
+        // Ordering comparisons only make sense for scalars
+        guard case .integer(let l) = lhs, case .integer(let r) = rhs else {
+            throw EvaluationError.unsupportedComparison(opText)
+        }
+        switch opText {
+        case "<":  result = l < r
+        case ">":  result = l > r
+        case "<=": result = l <= r
+        case ">=": result = l >= r
+        default: fatalError("unreachable")
+        }
     default: throw EvaluationError.unsupportedComparison(opText)
     }
 

--- a/Sources/PeanoNumbersMacros/GaussianMacro.swift
+++ b/Sources/PeanoNumbersMacros/GaussianMacro.swift
@@ -1,0 +1,39 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// `#Gaussian(re, im)` -- evaluates two integer expressions at compile time and
+/// expands to a `gaussian(...)` call with Peano types.
+///
+/// ```swift
+/// #Gaussian(1, 2)           // expands to: gaussian(AddOne<Zero>.self, AddOne<AddOne<Zero>>.self)
+/// #Gaussian(2 + 1, 3 * -1)  // expands to: gaussian(AddOne<AddOne<AddOne<Zero>>>.self, SubOne<SubOne<SubOne<Zero>>>.self)
+/// ```
+public struct GaussianMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        let args = Array(node.arguments)
+        guard args.count == 2 else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.gaussianRequiresTwoArguments)
+            ])
+        }
+
+        let re: Int
+        let im: Int
+        do {
+            re = try evaluateExpression(args[0].expression)
+            im = try evaluateExpression(args[1].expression)
+        } catch {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.unsupportedExpression)
+            ])
+        }
+
+        let reName = peanoTypeName(for: re)
+        let imName = peanoTypeName(for: im)
+        return "gaussian(\(raw: reName).self, \(raw: imName).self)"
+    }
+}

--- a/Sources/PeanoNumbersMacros/PeanoAssertMacro.swift
+++ b/Sources/PeanoNumbersMacros/PeanoAssertMacro.swift
@@ -13,9 +13,9 @@ public struct PeanoAssertMacro: ExpressionMacro {
             ])
         }
 
-        let comparison: (lhs: Int, rhs: Int, op: String, result: Bool)
+        let comparison: (lhs: EvalValue, rhs: EvalValue, op: String, result: Bool)
         do {
-            comparison = try evaluateComparison(argument)
+            comparison = try evaluateAlgebraComparison(argument)
         } catch {
             throw DiagnosticsError(diagnostics: [
                 Diagnostic(node: Syntax(argument), message: PeanoDiagnostic.expectedComparison)
@@ -27,14 +27,16 @@ public struct PeanoAssertMacro: ExpressionMacro {
         }
 
         // Build a helpful failure message
+        let lhsStr = formatEvalValue(comparison.lhs)
+        let rhsStr = formatEvalValue(comparison.rhs)
         let message: String
         if comparison.op == "==" {
             let lhsExpr = argument.as(InfixOperatorExprSyntax.self)!.leftOperand
-            message = "Peano assertion failed: \(lhsExpr.description.trimmingCharacters(in: .whitespaces)) is \(comparison.lhs), not \(comparison.rhs)"
+            message = "Peano assertion failed: \(lhsExpr.description.trimmingCharacters(in: .whitespaces)) is \(lhsStr), not \(rhsStr)"
         } else if comparison.op == "!=" {
-            message = "Peano assertion failed: \(comparison.lhs) != \(comparison.rhs) is false"
+            message = "Peano assertion failed: \(lhsStr) != \(rhsStr) is false"
         } else {
-            message = "Peano assertion failed: \(comparison.lhs) \(comparison.op) \(comparison.rhs) is false"
+            message = "Peano assertion failed: \(lhsStr) \(comparison.op) \(rhsStr) is false"
         }
 
         throw DiagnosticsError(diagnostics: [

--- a/Sources/PeanoNumbersMacros/Plugin.swift
+++ b/Sources/PeanoNumbersMacros/Plugin.swift
@@ -8,5 +8,6 @@ struct PeanoNumbersPlugin: CompilerPlugin {
         PeanoTypeMacro.self,
         PeanoAssertMacro.self,
         ChurchMacro.self,
+        GaussianMacro.self,
     ]
 }

--- a/Tests/PeanoNumbersMacrosTests/GaussianMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/GaussianMacroTests.swift
@@ -1,0 +1,73 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(PeanoNumbersMacros)
+import PeanoNumbersMacros
+
+nonisolated(unsafe) let gaussianMacros: [String: Macro.Type] = [
+    "Gaussian": GaussianMacro.self,
+]
+#endif
+
+final class GaussianMacroTests: XCTestCase {
+    #if canImport(PeanoNumbersMacros)
+
+    func testBothPositive() throws {
+        assertMacroExpansion(
+            "#Gaussian(1, 2)",
+            expandedSource: "gaussian(AddOne<Zero>.self, AddOne<AddOne<Zero>>.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testBothNegative() throws {
+        assertMacroExpansion(
+            "#Gaussian(-1, -2)",
+            expandedSource: "gaussian(SubOne<Zero>.self, SubOne<SubOne<Zero>>.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testMixedSigns() throws {
+        assertMacroExpansion(
+            "#Gaussian(3, -1)",
+            expandedSource: "gaussian(AddOne<AddOne<AddOne<Zero>>>.self, SubOne<Zero>.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testZeros() throws {
+        assertMacroExpansion(
+            "#Gaussian(0, 0)",
+            expandedSource: "gaussian(Zero.self, Zero.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testExpressionArguments() throws {
+        assertMacroExpansion(
+            "#Gaussian(1 + 2, 3 * -1)",
+            expandedSource: "gaussian(AddOne<AddOne<AddOne<Zero>>>.self, SubOne<SubOne<SubOne<Zero>>>.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testRealWithZeroImaginary() throws {
+        assertMacroExpansion(
+            "#Gaussian(5, 0)",
+            expandedSource: "gaussian(AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>.self, Zero.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    func testPureImaginary() throws {
+        assertMacroExpansion(
+            "#Gaussian(0, 1)",
+            expandedSource: "gaussian(Zero.self, AddOne<Zero>.self)",
+            macros: gaussianMacros
+        )
+    }
+
+    #endif
+}

--- a/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/PeanoAssertMacroTests.swift
@@ -213,5 +213,77 @@ final class PeanoAssertMacroTests: XCTestCase {
         )
     }
 
+    // MARK: - Cayley-Dickson assertions
+
+    func testGaussianAdditionPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(1, 2) + gaussian(3, -1) == gaussian(4, 1))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testGaussianMultiplicationPasses() throws {
+        // (1+2i)(3-i) = 3 - i + 6i - 2i² = 5 + 5i
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(1, 2) * gaussian(3, -1) == gaussian(5, 5))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testConjugatePasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(conjugate(gaussian(1, 2)) == gaussian(1, -2))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testNormPasses() throws {
+        // |1+2i|² = 1 + 4 = 5
+        assertMacroExpansion(
+            "#PeanoAssert(norm(gaussian(1, 2)) == 5)",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testGaussianEqualityFails() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(1, 2) + gaussian(3, 0) == gaussian(5, 2))",
+            expandedSource: "#PeanoAssert(gaussian(1, 2) + gaussian(3, 0) == gaussian(5, 2))",
+            diagnostics: [
+                DiagnosticSpec(message: "Peano assertion failed: gaussian(1, 2) + gaussian(3, 0) is (4, 2), not (5, 2)", line: 1, column: 1),
+            ],
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testGaussianInequalityPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(1, 2) != gaussian(1, 3))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testGaussianSubtractionPasses() throws {
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(3, 1) - gaussian(1, 2) == gaussian(2, -1))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
+    func testImaginaryUnitSquaredPasses() throws {
+        // i² = -1: gaussian(0,1) * gaussian(0,1) = gaussian(-1, 0)
+        assertMacroExpansion(
+            "#PeanoAssert(gaussian(0, 1) * gaussian(0, 1) == gaussian(-1, 0))",
+            expandedSource: "()",
+            macros: peanoAssertMacros
+        )
+    }
+
     #endif
 }

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -705,3 +705,81 @@ assert(qi * qj != qj * qi)
 let q1 = quaternion(One, Two, Three, Four)
 let Thirty = AlgebraValue.scalar(Six * Five)
 assert(norm(q1) == Thirty)
+
+// MARK: - Sign-parameterized Cayley-Dickson
+
+/// Sign parameter for generalized Cayley-Dickson multiplication.
+enum CayleyDicksonSign {
+    case standard  // ε = -1
+    case split     // ε = +1
+    case dual      // ε = 0
+}
+
+/// Multiplication with explicit sign parameter.
+func multiply(_ lhs: AlgebraValue, _ rhs: AlgebraValue,
+              sign: CayleyDicksonSign = .standard) -> AlgebraValue {
+    let d = max(depth(lhs), depth(rhs))
+    return mulSameDepth(embed(lhs, toDepth: d), embed(rhs, toDepth: d), sign: sign)
+}
+
+private func mulSameDepth(_ lhs: AlgebraValue, _ rhs: AlgebraValue,
+                          sign: CayleyDicksonSign) -> AlgebraValue {
+    switch (lhs, rhs) {
+    case (.scalar(let a), .scalar(let b)):
+        return .scalar((a as any Integer.Type) * (b as any Integer.Type))
+    case (.pair(let a, let b), .pair(let c, let d)):
+        let ac = mulSameDepth(a, c, sign: sign)
+        let conjD_b = mulSameDepth(conjugate(d), b, sign: sign)
+        let da = mulSameDepth(d, a, sign: sign)
+        let b_conjC = mulSameDepth(b, conjugate(c), sign: sign)
+
+        let realPart: AlgebraValue
+        switch sign {
+        case .standard: realPart = addSameDepth(ac, negate(conjD_b))
+        case .split:    realPart = addSameDepth(ac, conjD_b)
+        case .dual:     realPart = ac
+        }
+
+        return .pair(realPart, addSameDepth(da, b_conjC))
+    default:
+        fatalError("AlgebraValue depth mismatch in mulSameDepth")
+    }
+}
+
+/// Norm with explicit sign parameter.
+func norm(_ a: AlgebraValue, sign: CayleyDicksonSign) -> AlgebraValue {
+    switch a {
+    case .scalar(let n):
+        return .scalar((n as any Integer.Type) * (n as any Integer.Type))
+    case .pair(let re, let im):
+        let nRe = norm(re, sign: sign)
+        let nIm = norm(im, sign: sign)
+        switch sign {
+        case .standard: return addSameDepth(nRe, nIm)
+        case .split:    return addSameDepth(nRe, negate(nIm))
+        case .dual:     return nRe
+        }
+    }
+}
+
+// -- Split-complex: j² = +1 --
+
+let splitJ = gaussian(Zip, One)
+assert(multiply(splitJ, splitJ, sign: .split) == gaussian(One, Zip))
+
+// -- Standard: i² = -1 (unchanged) --
+
+assert(multiply(splitJ, splitJ, sign: .standard) == gaussian(MinusOne, Zip))
+
+// -- Dual: ε² = 0 --
+
+assert(multiply(splitJ, splitJ, sign: .dual) == gaussian(Zip, Zip))
+
+// -- Dual norm: N_dual(a + εb) = a² --
+
+let onePlusJ = gaussian(One, One)
+assert(norm(onePlusJ, sign: .dual) == AlgebraValue.scalar(One))
+
+// -- Split norm: N_split(a + jb) = a² - b² --
+
+assert(norm(onePlusJ, sign: .split) == AlgebraValue.scalar(Zip))


### PR DESCRIPTION
Closes #15

## Summary

- **Sign-parameterized Cayley-Dickson**: `CayleyDicksonSign` enum (`.standard`, `.split`, `.dual`) with `multiply(_:_:sign:)` and `norm(_:sign:)`. The `*` operator delegates to `.standard`, preserving backward compatibility. Split-complex (j^2=+1) and dual (e^2=0) algebras are now expressible.
- **`#Gaussian(re, im)` macro**: evaluates two integer expressions at compile time, expands to `gaussian(PeanoType.self, PeanoType.self)`.
- **Algebra evaluator**: `EvalValue` indirect enum extends the macro evaluator beyond `Int` to handle Cayley-Dickson pairs. `#PeanoAssert` now verifies `gaussian()`, `conjugate()`, `norm()`, and pair arithmetic at compile time.

## Test plan

- [x] `swift build` compiles without errors
- [x] `swift run PeanoNumbersClient` -- all runtime assertions pass (sign-param + #Gaussian)
- [x] `swift test` -- 66 tests pass (51 existing + 7 GaussianMacro + 8 PeanoAssert Cayley-Dickson)
- [x] `xcodebuild` -- Xcode target builds and runs with sign-parameterized assertions