### PR TITLE
Cleanup refactoring: SPM package, macros, Xcode deduplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,13 @@ The project has both an Xcode command-line tool and an SPM package:
 ```
 Package.swift                            -- SPM package definition
 type-level-natural-numbers.xcodeproj     -- Xcode project (standalone, does not use SPM)
-type-level-natural-numbers/main.swift    -- Xcode target entry point (convenience bindings, assertions, type-level arithmetic)
+type-level-natural-numbers/main.swift    -- Xcode target entry point (convenience bindings, representative runtime assertions)
 Sources/
   PeanoNumbers/                          -- library: types, operators, macro declarations
     PeanoTypes.swift                     -- protocols, Zero, AddOne, SubOne, operators, assertEqual
     ChurchNumerals.swift                 -- Church numeral encoding (ChurchNumeral, ChurchZero, ChurchSucc, ChurchAdd, ChurchMul)
     CayleyDickson.swift                  -- Cayley-Dickson construction (Algebra, AlgebraValue, CayleyDickson, gaussian, quaternion, sign-parameterized multiply/norm)
-    Macros.swift                         -- @freestanding macro declarations
+    Macros.swift                         -- macro declarations (#Peano, #PeanoType, #PeanoAssert, #Church, #Gaussian, @ProductConformance)
   PeanoNumbersMacros/                    -- .macro target: compiler plugin
     Plugin.swift                         -- CompilerPlugin entry point
     PeanoMacro.swift                     -- #Peano(n) implementation
@@ -23,10 +23,11 @@ Sources/
     PeanoAssertMacro.swift               -- #PeanoAssert(expr) implementation
     ChurchMacro.swift                    -- #Church(n) implementation
     GaussianMacro.swift                  -- #Gaussian(re, im) implementation
+    ProductConformanceMacro.swift        -- @ProductConformance(n) implementation (peer macro for inductive multiplication)
     ExpressionEvaluator.swift            -- shared arithmetic/algebra evaluator (EvalValue, evaluateAlgebraExpression)
     Diagnostics.swift                    -- PeanoDiagnostic enum, SimpleDiagnosticMessage
   PeanoNumbersClient/                    -- SPM executable: exercises everything
-    main.swift                           -- convenience bindings, runtime + compile-time assertions
+    main.swift                           -- convenience bindings, runtime + compile-time assertions, type-level arithmetic (Sum, Product)
 Tests/
   PeanoNumbersMacrosTests/               -- macro expansion tests
     PeanoMacroTests.swift
@@ -34,6 +35,7 @@ Tests/
     PeanoAssertMacroTests.swift
     ChurchMacroTests.swift
     GaussianMacroTests.swift
+    ProductConformanceMacroTests.swift
 ```
 
 ## Building and testing
@@ -52,7 +54,7 @@ swift test                   # run macro expansion tests
 xcodebuild -project type-level-natural-numbers.xcodeproj -scheme type-level-natural-numbers -configuration Debug build
 ```
 
-The Xcode target is self-contained -- it does not depend on the SPM package. It compiles the shared library sources (PeanoTypes.swift, CayleyDickson.swift, ChurchNumerals.swift) directly, and main.swift adds convenience bindings, representative assertions, and Xcode-exclusive type-level arithmetic (NaturalExpression, Sum, Product).
+The Xcode target is self-contained -- it does not depend on the SPM package. It compiles the shared library sources (PeanoTypes.swift, CayleyDickson.swift, ChurchNumerals.swift) directly, and main.swift adds convenience bindings and representative runtime assertions. Type-level arithmetic (NaturalExpression, Sum, Product) lives in the SPM client where macros are available.
 
 ### Testing conventions
 

--- a/Sources/PeanoNumbers/Macros.swift
+++ b/Sources/PeanoNumbers/Macros.swift
@@ -12,3 +12,6 @@ public macro Church(_ value: Int) -> any ChurchNumeral.Type = #externalMacro(mod
 
 @freestanding(expression)
 public macro Gaussian(_ re: Any, _ im: Any) -> AlgebraValue = #externalMacro(module: "PeanoNumbersMacros", type: "GaussianMacro")
+
+@attached(peer, names: arbitrary)
+public macro ProductConformance(_ multiplier: Int) = #externalMacro(module: "PeanoNumbersMacros", type: "ProductConformanceMacro")

--- a/Sources/PeanoNumbersMacros/Diagnostics.swift
+++ b/Sources/PeanoNumbersMacros/Diagnostics.swift
@@ -12,6 +12,7 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case unsupportedComparison = "Unsupported comparison operator"
     case churchRequiresNonnegative = "#Church requires a nonnegative integer literal (e.g. #Church(3))"
     case gaussianRequiresTwoArguments = "#Gaussian requires two integer expression arguments (e.g. #Gaussian(1, 2))"
+    case productConformanceRequiresMultiplier = "#ProductConformance requires an integer literal >= 2"
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "PeanoNumbersMacros", id: rawValue) }

--- a/Sources/PeanoNumbersMacros/Plugin.swift
+++ b/Sources/PeanoNumbersMacros/Plugin.swift
@@ -9,5 +9,6 @@ struct PeanoNumbersPlugin: CompilerPlugin {
         PeanoAssertMacro.self,
         ChurchMacro.self,
         GaussianMacro.self,
+        ProductConformanceMacro.self,
     ]
 }

--- a/Sources/PeanoNumbersMacros/ProductConformanceMacro.swift
+++ b/Sources/PeanoNumbersMacros/ProductConformanceMacro.swift
@@ -1,0 +1,74 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// `@ProductConformance(n)` -- generates an inductive protocol, conformances, and
+/// a `Product` extension for type-level multiplication by `n`.
+///
+/// Attach to the `Product` enum declaration:
+/// ```swift
+/// @ProductConformance(2)
+/// @ProductConformance(3)
+/// enum Product<L: Natural, R: Natural> {}
+/// ```
+///
+/// Each `@ProductConformance(2)` expands to peer declarations:
+/// ```swift
+/// protocol _TimesN2: Natural {
+///     associatedtype _TimesN2Result: Natural
+/// }
+/// extension Zero: _TimesN2 {
+///     typealias _TimesN2Result = Zero
+/// }
+/// extension AddOne: _TimesN2 where Predecessor: _TimesN2 {
+///     typealias _TimesN2Result = AddOne<AddOne<Predecessor._TimesN2Result>>
+/// }
+/// extension Product where L == AddOne<AddOne<Zero>>, R: _TimesN2 {
+///     typealias Result = R._TimesN2Result
+/// }
+/// ```
+public struct ProductConformanceMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+              let argument = arguments.first?.expression,
+              let literal = argument.as(IntegerLiteralExprSyntax.self),
+              let n = Int(literal.literal.text),
+              n >= 2 else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.productConformanceRequiresMultiplier)
+            ])
+        }
+
+        let proto = "_TimesN\(n)"
+        let assoc = "_TimesN\(n)Result"
+        let addOneChain = String(repeating: "AddOne<", count: n) + "Predecessor.\(assoc)" + String(repeating: ">", count: n)
+        let lType = peanoTypeName(for: n)
+
+        return [
+            """
+            protocol \(raw: proto): Natural {
+                associatedtype \(raw: assoc): Natural
+            }
+            """,
+            """
+            extension Zero: \(raw: proto) {
+                typealias \(raw: assoc) = Zero
+            }
+            """,
+            """
+            extension AddOne: \(raw: proto) where Predecessor: \(raw: proto) {
+                typealias \(raw: assoc) = \(raw: addOneChain)
+            }
+            """,
+            """
+            extension Product where L == \(raw: lType), R: \(raw: proto) {
+                typealias Result = R.\(raw: assoc)
+            }
+            """,
+        ]
+    }
+}

--- a/Tests/PeanoNumbersMacrosTests/ProductConformanceMacroTests.swift
+++ b/Tests/PeanoNumbersMacrosTests/ProductConformanceMacroTests.swift
@@ -1,0 +1,107 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(PeanoNumbersMacros)
+import PeanoNumbersMacros
+
+nonisolated(unsafe) let productConformanceMacros: [String: Macro.Type] = [
+    "ProductConformance": ProductConformanceMacro.self,
+]
+#endif
+
+final class ProductConformanceMacroTests: XCTestCase {
+    #if canImport(PeanoNumbersMacros)
+
+    func testTimesTwo() throws {
+        assertMacroExpansion(
+            """
+            @ProductConformance(2)
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            expandedSource: """
+            enum Product<L: Natural, R: Natural> {}
+
+            protocol _TimesN2: Natural {
+                associatedtype _TimesN2Result: Natural
+            }
+
+            extension Zero: _TimesN2 {
+                typealias _TimesN2Result = Zero
+            }
+
+            extension AddOne: _TimesN2 where Predecessor: _TimesN2 {
+                typealias _TimesN2Result = AddOne<AddOne<Predecessor._TimesN2Result>>
+            }
+
+            extension Product where L == AddOne<AddOne<Zero>>, R: _TimesN2 {
+                typealias Result = R._TimesN2Result
+            }
+            """,
+            macros: productConformanceMacros
+        )
+    }
+
+    func testTimesThree() throws {
+        assertMacroExpansion(
+            """
+            @ProductConformance(3)
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            expandedSource: """
+            enum Product<L: Natural, R: Natural> {}
+
+            protocol _TimesN3: Natural {
+                associatedtype _TimesN3Result: Natural
+            }
+
+            extension Zero: _TimesN3 {
+                typealias _TimesN3Result = Zero
+            }
+
+            extension AddOne: _TimesN3 where Predecessor: _TimesN3 {
+                typealias _TimesN3Result = AddOne<AddOne<AddOne<Predecessor._TimesN3Result>>>
+            }
+
+            extension Product where L == AddOne<AddOne<AddOne<Zero>>>, R: _TimesN3 {
+                typealias Result = R._TimesN3Result
+            }
+            """,
+            macros: productConformanceMacros
+        )
+    }
+
+    func testZeroProducesDiagnostic() throws {
+        assertMacroExpansion(
+            """
+            @ProductConformance(0)
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            expandedSource: """
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "#ProductConformance requires an integer literal >= 2", line: 1, column: 1)
+            ],
+            macros: productConformanceMacros
+        )
+    }
+
+    func testOneProducesDiagnostic() throws {
+        assertMacroExpansion(
+            """
+            @ProductConformance(1)
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            expandedSource: """
+            enum Product<L: Natural, R: Natural> {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "#ProductConformance requires an integer literal >= 2", line: 1, column: 1)
+            ],
+            macros: productConformanceMacros
+        )
+    }
+
+    #endif
+}

--- a/type-level-natural-numbers/main.swift
+++ b/type-level-natural-numbers/main.swift
@@ -5,17 +5,9 @@
 // This file contains:
 //   1. Convenience bindings
 //   2. Representative runtime assertions (verify shared sources)
-//   3. Type-level arithmetic (Xcode-exclusive: NaturalExpression, Sum, Product)
-
-// MARK: - Type aliases for type-level arithmetic
-
-typealias N0 = Zero
-typealias N1 = AddOne<N0>
-typealias N2 = AddOne<N1>
-typealias N3 = AddOne<N2>
-typealias N4 = AddOne<N3>
-typealias N5 = AddOne<N4>
-typealias N6 = AddOne<N5>
+//
+// Type-level arithmetic (NaturalExpression, Sum, Product) lives in the SPM client
+// where macros are available.
 
 // MARK: - Convenience bindings
 
@@ -90,112 +82,3 @@ let splitJ = gaussian(Zip, One)
 assert(multiply(splitJ, splitJ, sign: .split) == gaussian(One, Zip))
 assert(multiply(splitJ, splitJ, sign: .standard) == gaussian(MinusOne, Zip))
 assert(multiply(splitJ, splitJ, sign: .dual) == gaussian(Zip, Zip))
-
-// MARK: - Type-level arithmetic (Xcode-exclusive)
-
-/// A type-level computation that evaluates to a `Natural` type.
-protocol NaturalExpression {
-    associatedtype Result: Natural
-}
-
-// MARK: Sum
-
-/// Type-level addition. `Sum<L, R>.Result` resolves to the concrete
-/// `AddOne<...>` chain representing L + R at compile time.
-///
-/// Swift does not support multiple conditional conformances of the same
-/// protocol, so the base case (L == Zero) uses a protocol conformance
-/// while the recursive cases use constrained extensions with typealiases.
-enum Sum<L: Natural, R: Natural> {}
-
-extension Sum: NaturalExpression where L == Zero {
-    typealias Result = R                                    // 0 + R = R
-}
-
-extension Sum where L == N1 {
-    typealias Result = AddOne<R>                            // 1 + R = R + 1
-}
-
-extension Sum where L == N2 {
-    typealias Result = AddOne<AddOne<R>>                    // 2 + R = R + 2
-}
-
-extension Sum where L == N3 {
-    typealias Result = AddOne<AddOne<AddOne<R>>>            // 3 + R = R + 3
-}
-
-// MARK: Inductive multiplication helpers
-
-/// Inductive protocol for type-level multiplication by 2.
-/// Every concrete `Natural` type satisfies this via the conditional
-/// conformance chain on `AddOne`.
-protocol DoublableNatural: Natural {
-    associatedtype Doubled: Natural
-}
-
-extension Zero: DoublableNatural {
-    typealias Doubled = Zero                                    // 0 * 2 = 0
-}
-
-extension AddOne: DoublableNatural where Predecessor: DoublableNatural {
-    typealias Doubled = AddOne<AddOne<Predecessor.Doubled>>     // S(n) * 2 = n*2 + 2
-}
-
-/// Inductive protocol for type-level multiplication by 3.
-protocol TriplableNatural: Natural {
-    associatedtype Tripled: Natural
-}
-
-extension Zero: TriplableNatural {
-    typealias Tripled = Zero                                    // 0 * 3 = 0
-}
-
-extension AddOne: TriplableNatural where Predecessor: TriplableNatural {
-    typealias Tripled = AddOne<AddOne<AddOne<Predecessor.Tripled>>>  // S(n) * 3 = n*3 + 3
-}
-
-// MARK: Product
-
-/// Type-level multiplication. `Product<L, R>.Result` resolves to the
-/// concrete `AddOne<...>` chain representing L * R at compile time.
-///
-/// The base cases (L == Zero, L == N1) are generic over R. For larger
-/// multipliers, inductive helper protocols (`DoublableNatural`,
-/// `TriplableNatural`) thread the recursion through conditional
-/// conformance on `AddOne`, allowing a single extension per multiplier
-/// that works for any R.
-enum Product<L: Natural, R: Natural> {}
-
-extension Product: NaturalExpression where L == Zero {
-    typealias Result = Zero                                 // 0 * R = 0
-}
-
-extension Product where L == N1 {
-    typealias Result = R                                    // 1 * R = R
-}
-
-extension Product where L == N2, R: DoublableNatural {
-    typealias Result = R.Doubled                            // 2 * R (inductive)
-}
-
-extension Product where L == N3, R: TriplableNatural {
-    typealias Result = R.Tripled                            // 3 * R (inductive)
-}
-
-// Compile-time addition
-assertEqual(Sum<N0, N0>.Result.self, Zip)
-assertEqual(Sum<N1, N0>.Result.self, One)
-assertEqual(Sum<N0, N1>.Result.self, One)
-assertEqual(Sum<N1, N2>.Result.self, Three)    // 1 + 2 = 3
-assertEqual(Sum<N2, N2>.Result.self, Four)     // 2 + 2 = 4
-
-// Compile-time multiplication
-assertEqual(Product<N0, N1>.Result.self, Zip)  // 0 * 1 = 0
-assertEqual(Product<N1, N2>.Result.self, Two)  // 1 * 2 = 2
-assertEqual(Product<N2, N2>.Result.self, Four) // 2 * 2 = 4
-assertEqual(Product<N2, N3>.Result.self, Six)  // 2 * 3 = 6
-
-// Inductive multiplication -- no per-R extensions needed:
-assertEqual(Product<N2, N4>.Result.self, AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<AddOne<Zero>>>>>>>>.self)  // 2 * 4 = 8
-assertEqual(Product<N3, N1>.Result.self, Three)    // 3 * 1 = 3
-assertEqual(Product<N3, N2>.Result.self, Six)      // 3 * 2 = 6


### PR DESCRIPTION
## Summary

- Add SPM package structure with library, macro plugin, and client executable
- Implement 6 Swift macros for compile-time arithmetic (`#Peano`, `#PeanoType`, `#PeanoAssert`, `#Church`, `#Gaussian`, `@ProductConformance`)
- Simplify protocol hierarchy, add extended arithmetic, Church numerals, and Cayley-Dickson construction
- Deduplicate Xcode target by sharing SPM library sources
- Move type-level arithmetic to SPM client; simplify Xcode main.swift to runtime assertions only

Closes #19

## Test plan

- [ ] `swift build` compiles all targets
- [ ] `swift run PeanoNumbersClient` passes all runtime assertions
- [ ] `swift test` passes all 70 macro expansion tests
- [ ] `xcodebuild -project type-level-natural-numbers.xcodeproj -scheme type-level-natural-numbers build` succeeds
- [ ] Run Xcode binary -- runtime assertions pass