### PR TITLE
Prove associativity of addition via ProofSeed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Sources/
     CayleyDickson.swift                      -- Cayley-Dickson construction (Algebra marker protocol, CayleyDickson type)
     ContinuedFractions.swift                 -- Fraction, GCFConvergent (CF convergents), LeibnizPartialSum (Leibniz series), Matrix2x2, Mat2, Sqrt2MatStep (matrix construction)
     Fibonacci.swift                          -- FibState, FibVerified, Fib0, FibStep (Fibonacci recurrence witnesses)
-    AdditionTheorems.swift                   -- universal addition theorems (AddLeftZero, SuccLeftAdd, AddCommutative)
+    AdditionTheorems.swift                   -- universal addition theorems (AddLeftZero, SuccLeftAdd, AddCommutative, AddAssociative via ProofSeed)
     Macros.swift                             -- macro declarations (@ProductConformance, @FibonacciProof, @PiConvergenceProof, @GoldenRatioProof, @Sqrt2ConvergenceProof)
   AbuseOfNotationMacros/                     -- .macro target: compiler plugin
     Plugin.swift                             -- CompilerPlugin entry point
@@ -70,6 +70,8 @@ swift test                       # run macro expansion tests
 - The macro is the proof SEARCH (arbitrary integer computation at compile time); the type checker is the proof VERIFIER (structural constraint verification).
 - Universal theorems use conditional conformance as structural induction: a base case on `Zero`/`PlusZero` and an inductive step on `AddOne`/`PlusSucc`. Protocols use plain associated types (no `where` clauses) following the `_TimesNk` pattern to avoid rewrite system limits; correctness is enforced structurally by the conformance definitions.
 - `AddLeftZero` proves `0 + n = n` for all n. `SuccLeftAdd` proves `a + b = c => S(a) + b = S(c)` for all proofs. `AddCommutative` proves `a + b = c => b + a = c` for all proofs (combines the first two).
+- `ProofSeed<P>` is a `Natural`-conforming enum that wraps a `NaturalSum` proof as a base case for inductive proof extension. Analogous to `Seed<A>` but wraps a proof instead of a number.
+- `AddAssociative` proves associativity: given P witnessing `a + b = d`, `AddOne^c(ProofSeed<P>).AssocProof = PlusSucc^c(P)` witnesses `a + (b + c) = d + c`. Universality is parametric over P and inductive over c.
 
 ## Branching
 
@@ -77,3 +79,4 @@ swift test                       # run macro expansion tests
 - `witness-based-proofs` -- PR 1: paradigm shift from runtime computation to witness-based proofs.
 - `macro-cleanup` -- PR 2: removes computational macros, Xcode target, updates docs.
 - `continued-fractions` -- PR 3: golden ratio CF/Fibonacci and sqrt(2) CF/matrix correspondence proofs.
+- `addition-associativity` -- PR for issue #29: associativity of addition via ProofSeed.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ extension PlusSucc: AddCommutative
     where Proof: AddCommutative, Proof.Commuted: SuccLeftAdd { ... }  // inductive step
 ```
 
+### Associativity: `(a + b) + c = a + (b + c)`
+
+Associativity is a binary theorem requiring two addition proofs (one for `a + b`, one for the result plus `c`). Swift protocols can only do induction on one type parameter. The `ProofSeed` technique solves this by encoding one proof as a seed type and doing induction on the other:
+
+```swift
+// ProofSeed<P>: a Natural wrapping a NaturalSum proof as a base case
+// AddAssociative: for any chain AddOne^c(ProofSeed<P>), the AssocProof is PlusSucc^c(P)
+typealias Assoc3p2p4 = AddOne<AddOne<AddOne<AddOne<ProofSeed<ThreePlusTwo>>>>>
+// AssocProof witnesses 3 + 6 = 9 (i.e. 3 + (2+4) = (3+2) + 4)
+assertEqual(Assoc3p2p4.AssocProof.Total.self, N9.self)
+```
+
+Universality is twofold: parametric over the seed proof (any `NaturalSum`) and inductive over the extension depth (any natural number).
+
 ## sqrt(2) CF and matrix construction
 
 The sqrt(2) continued fraction [1; 2, 2, 2, ...] has convergents that can be computed either by the three-term recurrence (h_n = 2h_{n-1} + h_{n-2}) or by iterated left-multiplication by the matrix [[2,1],[1,0]]. The `@Sqrt2ConvergenceProof(depth:)` macro constructs both representations and proves they agree:

--- a/Sources/AbuseOfNotation/AdditionTheorems.swift
+++ b/Sources/AbuseOfNotation/AdditionTheorems.swift
@@ -80,3 +80,34 @@ extension PlusSucc: AddCommutative
 {
     public typealias Commuted = Proof.Commuted.Shifted
 }
+
+// MARK: - Theorem 4: Associativity ((a + b) + c = a + (b + c))
+
+/// A Natural wrapping a NaturalSum proof, serving as base case for proof
+/// extension. Analogous to Seed<A> for _InductiveAdd, but wraps a proof
+/// instead of a number.
+///
+/// Building c layers of AddOne on ProofSeed<P> and extracting AssocProof
+/// yields PlusSucc^c(P): the associativity proof.
+public enum ProofSeed<P: NaturalSum>: Natural {
+    public typealias Successor = AddOne<Self>
+    public typealias Predecessor = SubOne<Zero>
+}
+
+/// For any chain AddOne^c(ProofSeed<P>), the AssocProof is PlusSucc^c(P),
+/// witnessing a + (b + c) = d + c where P witnesses a + b = d.
+///
+/// Universality is twofold: parametric over P (any proof) and inductive
+/// over c (any natural). This solves the "two-variable" problem noted in
+/// section 5.2 of the future-work document.
+public protocol AddAssociative: Natural {
+    associatedtype AssocProof: NaturalSum
+}
+
+extension ProofSeed: AddAssociative {
+    public typealias AssocProof = P
+}
+
+extension AddOne: AddAssociative where Predecessor: AddAssociative {
+    public typealias AssocProof = PlusSucc<Predecessor.AssocProof>
+}

--- a/docs/future-work-inductive-proofs-and-irrationals.md
+++ b/docs/future-work-inductive-proofs-and-irrationals.md
@@ -343,7 +343,9 @@ protocol Commutative {
 
 But there is no way to have `AddOne` conditionally conform to this for all values of `M` simultaneously. Each conditional conformance fixes the structure of one generic parameter, not two. We would need a protocol parameterized by both, which Swift protocols do not support.
 
-**Possible workaround**: A macro could generate conformances for all pairs up to a fixed bound, giving a finite approximation to the universal statement. This is not a proof for all naturals, but it could catch errors in the formulation.
+**Partial solution (ProofSeed)**: The `ProofSeed` technique solves the two-variable problem for associativity. `ProofSeed<P>` wraps a `NaturalSum` proof as a `Natural`, and `AddAssociative` does induction over `AddOne` layers on top. Given P witnessing `a + b = d`, `AddOne^c(ProofSeed<P>).AssocProof = PlusSucc^c(P)` witnesses `a + (b + c) = d + c`. Universality is parametric over P (any proof) and inductive over c (any natural). This avoids the two-parameter protocol problem by encoding one axis as a type parameter and inducting over the other.
+
+**Remaining limitation**: A macro could generate conformances for all pairs up to a fixed bound, giving a finite approximation to the universal statement. This is not a proof for all naturals, but it could catch errors in the formulation.
 
 ### 5.3 No negative reasoning or case analysis
 


### PR DESCRIPTION
## Summary

- Add `ProofSeed<P>` (a `Natural`-conforming enum wrapping a `NaturalSum` proof) and `AddAssociative` protocol to prove `(a + b) + c = a + (b + c)` for all proofs P and all naturals c
- Add Section 15 to `main.swift` with three concrete demonstrations verifying associativity via `assertEqual`
- Update documentation (CLAUDE.md, README.md, future-work doc section 5.2) to describe the ProofSeed technique

Closes #33
See also: #29

## Test plan

- [x] `swift build` succeeds (compilation = proof)
- [x] `swift run AbuseOfNotationClient` exits cleanly
- [x] `swift test` passes all 13 macro expansion tests
- [x] No changes to existing code -- only additions