### PR TITLE
Prove successor-left multiplication via flat encoding

### DIFF
--- a/Sources/AbuseOfNotation/MultiplicationTheorems.swift
+++ b/Sources/AbuseOfNotation/MultiplicationTheorems.swift
@@ -1,31 +1,41 @@
 // Universal multiplication theorems proved by structural induction.
+//
+// The flat encoding (TimesTick/TimesGroup) decomposes each multiplication
+// step into individual successor operations, like PlusSucc does for addition.
+// This avoids TimesSucc's where clauses, which trigger rewrite system
+// explosion when composed in inductive protocols.
 
-// MARK: - Derived lemma: zero-left multiplication step
+// MARK: - Flat multiplication witnesses
 
-/// Derived witness for the zero-left multiplication step.
-/// If 0 * B = 0 (witnessed by MulProof), then 0 * S(B) = 0.
+/// One successor step within a multiplication.
+/// Adds 1 to Total; Left and Right unchanged.
 ///
-/// This is a lemma derived from the Peano multiplication axiom:
-///   0 * S(B) = 0*B + 0 = 0 + 0 = 0
+/// Analogous to PlusSucc for addition: each TimesTick increments the running
+/// total by 1. A "copy of Left" consists of Left-many consecutive TimesTicks.
+public struct TimesTick<Proof: NaturalProduct>: NaturalProduct {
+    public typealias Left = Proof.Left
+    public typealias Right = Proof.Right
+    public typealias Total = AddOne<Proof.Total>
+}
+
+/// One complete copy of Left has been added.
+/// Adds 1 to Right; Left and Total unchanged.
 ///
-/// TimesSucc encodes the general step A * S(B) = A*B + A, but its where
-/// clauses (AddProof.Left == MulProof.Total, AddProof.Right == MulProof.Left)
-/// trigger rewrite system explosion when composed in inductive protocols.
-/// This lemma specializes to A = 0, where the arithmetic simplifies to
-/// 0 + 0 = 0, and encodes the result directly.
-public struct TimesZeroLeft<MulProof: NaturalProduct>: NaturalProduct {
-    public typealias Left = Zero
-    public typealias Right = AddOne<MulProof.Right>
-    public typealias Total = Zero
+/// After Left-many TimesTicks, a TimesGroup marks the boundary: one full
+/// copy of Left has been accumulated, so Right increments by 1.
+public struct TimesGroup<Proof: NaturalProduct>: NaturalProduct {
+    public typealias Left = Proof.Left
+    public typealias Right = AddOne<Proof.Right>
+    public typealias Total = Proof.Total
 }
 
 // MARK: - Theorem 1: Left zero annihilation (0 * n = 0)
 
 /// For any natural number N, there exists a proof that 0 * N = 0.
-/// Proved by induction on N using TimesZero (base) and TimesZeroLeft (step).
+/// Proved by induction on N using TimesZero (base) and TimesGroup (step).
 ///
-/// The associated type `ZeroTimesProof` is structurally guaranteed to be a
-/// `NaturalProduct` with `Left == Zero`, `Right == Self`, `Total == Zero`.
+/// With Left = 0, each group has 0 ticks (no TimesTicks needed), so the
+/// inductive step is just TimesGroup wrapping the previous proof.
 public protocol MulLeftZero: Natural {
     associatedtype ZeroTimesProof: NaturalProduct
 }
@@ -36,6 +46,40 @@ extension Zero: MulLeftZero {
 }
 
 // Inductive step: if 0 * n = 0, then 0 * S(n) = 0
+// Each group has 0 ticks (Left = 0), so just wrap with TimesGroup.
 extension AddOne: MulLeftZero where Predecessor: MulLeftZero {
-    public typealias ZeroTimesProof = TimesZeroLeft<Predecessor.ZeroTimesProof>
+    public typealias ZeroTimesProof = TimesGroup<Predecessor.ZeroTimesProof>
+}
+
+// MARK: - Theorem 2: Successor-left multiplication (a * b = c => S(a) * b = c + b)
+
+/// For any flat multiplication proof that a * b = c, there exists a proof
+/// that S(a) * b = c + b. Each TimesGroup gains one extra TimesTick
+/// (the new successor contributes one extra unit per copy), so b groups
+/// contribute b extra ticks: Total goes from c to c + b.
+///
+/// Structurally identical to how SuccLeftAdd wraps each PlusSucc.
+public protocol SuccLeftMul: NaturalProduct {
+    associatedtype Distributed: NaturalProduct
+}
+
+// Base case: TimesZero<N> witnesses N * 0 = 0
+// S(N) * 0 = 0, witnessed by TimesZero<S(N)>
+extension TimesZero: SuccLeftMul {
+    public typealias Distributed = TimesZero<AddOne<N>>
+}
+
+// Inductive step (tick): TimesTick<P> witnesses a * b = S(c) where P: a * b' = c
+// If P.Distributed witnesses S(a) * b' = d,
+// then TimesTick<P.Distributed> witnesses S(a) * b = S(d)
+extension TimesTick: SuccLeftMul where Proof: SuccLeftMul {
+    public typealias Distributed = TimesTick<Proof.Distributed>
+}
+
+// Inductive step (group): TimesGroup<P> witnesses a * S(b) = c where P: a * b = c
+// If P.Distributed witnesses S(a) * b = d,
+// then TimesGroup<TimesTick<P.Distributed>> witnesses S(a) * S(b) = S(d)
+// The extra TimesTick accounts for the new successor's contribution to this group.
+extension TimesGroup: SuccLeftMul where Proof: SuccLeftMul {
+    public typealias Distributed = TimesGroup<TimesTick<Proof.Distributed>>
 }


### PR DESCRIPTION
## Summary

- Introduces `TimesTick`/`TimesGroup`, a flat multiplication encoding that decomposes each multiplication step into individual successor operations (like `PlusSucc` does for addition), avoiding `TimesSucc`'s where clauses that trigger rewrite system explosion
- Replaces `TimesZeroLeft` with the simpler `TimesGroup`-based `MulLeftZero`
- Proves `SuccLeftMul`: for any flat proof of `a * b = c`, constructs a proof of `S(a) * b = c + b` by inserting one extra `TimesTick` per `TimesGroup`

## Test plan

- [x] `swift build` succeeds (compilation is the proof)
- [x] `swift run AbuseOfNotationClient` exits cleanly
- [x] `swift test` passes all 13 macro expansion tests
- [x] Concrete verification: `2*3=6 → 3*3=9`, `2*2=4 → 3*2=6`, `5*0=0 → 6*0=0`

Closes #30