### PR TITLE
Add @MulCommProof macro for commutativity proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ assertEqual(MulComm2x3.RevProof.Total.self, N6.self)  // 3 * 2 = 6
 
 The reverse direction chains universally because `SuccLeftMul.Distributed` is itself required to conform to `SuccLeftMul` (a strengthened self-referential constraint). The forward direction hardcodes A ticks per group, hence the per-A protocol structure.
 
+### Macro-generated commutativity proofs
+
+The `@MulCommProof(leftOperand: A, depth: D)` macro automates bounded-depth commutativity proofs for any A >= 2. It generates paired forward/reverse proof chains inside a namespace enum:
+
+```swift
+@MulCommProof(leftOperand: 4, depth: 5)
+enum MulComm4 {}
+
+assertEqual(MulComm4._Fwd3.Total.self, MulComm4._Rev3.Total.self)  // 4*3 = 3*4
+assertEqual(MulComm4._Fwd3.Total.self, N12.self)                    // = 12
+```
+
+Each `_FwdK` witnesses `A * K` using the flat encoding (A ticks per group), and each `_RevK` witnesses `K * A` via `SuccLeftMul.Distributed`. The type checker verifies that both Totals match at every depth.
+
 ## Coinductive streams for irrational numbers
 
 The convergent proofs above are bounded-depth: macros generate witness chains for specific values. Coinductive streams provide a complementary representation: the continued fraction coefficient sequence *itself* as a type.

--- a/Sources/AbuseOfNotation/Macros.swift
+++ b/Sources/AbuseOfNotation/Macros.swift
@@ -12,3 +12,6 @@ public macro GoldenRatioProof(depth n: Int) = #externalMacro(module: "AbuseOfNot
 
 @attached(member, names: arbitrary)
 public macro Sqrt2ConvergenceProof(depth n: Int) = #externalMacro(module: "AbuseOfNotationMacros", type: "Sqrt2ConvergenceProofMacro")
+
+@attached(member, names: arbitrary)
+public macro MulCommProof(leftOperand: Int, depth: Int) = #externalMacro(module: "AbuseOfNotationMacros", type: "MulCommProofMacro")

--- a/Sources/AbuseOfNotation/MultiplicationTheorems.swift
+++ b/Sources/AbuseOfNotation/MultiplicationTheorems.swift
@@ -149,3 +149,17 @@ extension AddOne: _MulCommN3 where Predecessor: _MulCommN3 {
     // Reverse: SuccLeftMul distributes successor across all groups
     public typealias RevProof = Predecessor.RevProof.Distributed
 }
+
+// MARK: - Macro-generated commutativity proofs
+//
+// The @MulCommProof macro generates bounded-depth paired proofs showing
+// A * b = b * A for b = 0 through the given depth. Each _FwdK witnesses
+// A * K (flat encoding) and each _RevK witnesses K * A (via SuccLeftMul).
+// The type checker verifies that both sides have the same Total.
+//
+// This is analogous to how @FibonacciProof and @PiConvergenceProof generate
+// bounded-depth proof chains. The manual _MulCommN2/_MulCommN3 protocols
+// above provide universal proofs (for all b); the macro generates verified
+// proofs up to a specific depth for any A >= 2.
+//
+// See main.swift Section 16 for @MulCommProof invocations and assertions.

--- a/Sources/AbuseOfNotationClient/main.swift
+++ b/Sources/AbuseOfNotationClient/main.swift
@@ -657,6 +657,34 @@ assertEqual(MulComm3x4.FwdProof.Right.self, N4.self)
 assertEqual(MulComm3x4.RevProof.Left.self, N4.self)   // 4 * 3
 assertEqual(MulComm3x4.RevProof.Right.self, N3.self)
 
+// -- Macro-generated commutativity proofs (N4, N5) --
+// The @MulCommProof macro generates bounded-depth paired proofs:
+//   _FwdK witnesses A * K (flat encoding)
+//   _RevK witnesses K * A (via SuccLeftMul.Distributed)
+// The type checker verifies that both Total types are equal.
+
+@MulCommProof(leftOperand: 4, depth: 5)
+enum MulComm4 {}
+
+@MulCommProof(leftOperand: 5, depth: 4)
+enum MulComm5 {}
+
+// N4: 4 * 3 = 3 * 4 = 12
+assertEqual(MulComm4._Fwd3.Total.self, MulComm4._Rev3.Total.self)
+assertEqual(MulComm4._Fwd3.Total.self, N12.self)
+assertEqual(MulComm4._Fwd3.Left.self, N4.self)   // 4 * 3
+assertEqual(MulComm4._Fwd3.Right.self, N3.self)
+assertEqual(MulComm4._Rev3.Left.self, N3.self)   // 3 * 4
+assertEqual(MulComm4._Rev3.Right.self, N4.self)
+
+// N5: 5 * 2 = 2 * 5 = 10
+assertEqual(MulComm5._Fwd2.Total.self, MulComm5._Rev2.Total.self)
+assertEqual(MulComm5._Fwd2.Total.self, N10.self)
+assertEqual(MulComm5._Fwd2.Left.self, N5.self)   // 5 * 2
+assertEqual(MulComm5._Fwd2.Right.self, N2.self)
+assertEqual(MulComm5._Rev2.Left.self, N2.self)   // 2 * 5
+assertEqual(MulComm5._Rev2.Right.self, N5.self)
+
 // MARK: - 17. Coinductive streams for irrational numbers
 //
 // The proofs above represent irrational numbers through bounded-depth
@@ -743,6 +771,7 @@ assertEqual(Sqrt2CF.Head.self, Sqrt2Proof._CF0.P.self)         // both N1
 // addition theorems (left zero identity, successor-left shift,
 // commutativity, and associativity), three universal multiplication
 // theorems (left zero annihilation, successor-left multiplication, and
-// per-A commutativity), and coinductive streams for irrational numbers
-// (PhiCF, Sqrt2CF with universal unfold theorems) -- all without
-// executing a single computation at runtime.
+// per-A commutativity -- including macro-generated proofs for N4 and N5),
+// and coinductive streams for irrational numbers (PhiCF, Sqrt2CF with
+// universal unfold theorems) -- all without executing a single
+// computation at runtime.

--- a/Sources/AbuseOfNotationMacros/Diagnostics.swift
+++ b/Sources/AbuseOfNotationMacros/Diagnostics.swift
@@ -6,6 +6,7 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case piConvergenceRequiresPositiveInteger = "#piConvergenceProof requires an integer literal >= 1"
     case goldenRatioRequiresPositiveInteger = "#goldenRatioProof requires an integer literal >= 1"
     case sqrt2ConvergenceRequiresPositiveInteger = "#sqrt2ConvergenceProof requires an integer literal >= 1"
+    case mulCommProofRequiresMultiplier = "#MulCommProof requires an integer literal >= 2"
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "AbuseOfNotationMacros", id: rawValue) }

--- a/Sources/AbuseOfNotationMacros/MulCommProofMacro.swift
+++ b/Sources/AbuseOfNotationMacros/MulCommProofMacro.swift
@@ -1,0 +1,93 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// `@MulCommProof(leftOperand: A, depth: D)` -- generates paired forward/reverse
+/// multiplication proof chains showing `A * b = b * A` for `b = 0` through `D`.
+///
+/// Attach to a namespace enum:
+/// ```swift
+/// @MulCommProof(leftOperand: 4, depth: 5)
+/// enum MulComm4 {}
+/// ```
+///
+/// Each expansion generates `D+1` paired typealiases:
+/// ```swift
+/// enum MulComm4 {
+///     typealias _Fwd0 = TimesZero<N4>
+///     typealias _Rev0 = N4.ZeroTimesProof
+///     typealias _Fwd1 = TimesGroup<TimesTick<TimesTick<TimesTick<TimesTick<_Fwd0>>>>>
+///     typealias _Rev1 = _Rev0.Distributed
+///     // ...
+/// }
+/// ```
+///
+/// The forward proof (`_FwdK`) witnesses `A * K` using the flat encoding:
+/// each step wraps in A `TimesTick`s plus one `TimesGroup`.
+/// The reverse proof (`_RevK`) witnesses `K * A` via `SuccLeftMul.Distributed`.
+/// The type checker verifies that `_FwdK.Total == _RevK.Total` when asserted.
+public struct MulCommProofMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.mulCommProofRequiresMultiplier)
+            ])
+        }
+
+        // Parse labeled arguments: leftOperand and depth
+        var leftOperand: Int?
+        var depth: Int?
+
+        for arg in arguments {
+            let label = arg.label?.text
+            guard let literal = arg.expression.as(IntegerLiteralExprSyntax.self),
+                  let value = Int(literal.literal.text) else {
+                continue
+            }
+            switch label {
+            case "leftOperand":
+                leftOperand = value
+            case "depth":
+                depth = value
+            default:
+                break
+            }
+        }
+
+        guard let a = leftOperand, a >= 2, let d = depth, d >= 1 else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.mulCommProofRequiresMultiplier)
+            ])
+        }
+
+        let peano = peanoTypeName(for: a)
+        var decls: [DeclSyntax] = []
+
+        // Base case (b = 0): A * 0 = 0 and 0 * A = 0
+        decls.append("typealias _Fwd0 = TimesZero<\(raw: peano)>")
+        decls.append("typealias _Rev0 = \(raw: peano).ZeroTimesProof")
+
+        // Inductive steps (b = 1 through d)
+        for b in 1...d {
+            let prev = "_Fwd\(b - 1)"
+
+            // Forward: TimesGroup<TimesTick^A<prev>>
+            let fwd = "TimesGroup<"
+                + String(repeating: "TimesTick<", count: a)
+                + prev
+                + String(repeating: ">", count: a + 1)
+
+            // Reverse: prev.Distributed
+            let rev = "_Rev\(b - 1).Distributed"
+
+            decls.append("typealias _Fwd\(raw: String(b)) = \(raw: fwd)")
+            decls.append("typealias _Rev\(raw: String(b)) = \(raw: rev)")
+        }
+
+        return decls
+    }
+}

--- a/Sources/AbuseOfNotationMacros/Plugin.swift
+++ b/Sources/AbuseOfNotationMacros/Plugin.swift
@@ -9,5 +9,6 @@ struct AbuseOfNotationPlugin: CompilerPlugin {
         PiConvergenceProofMacro.self,
         GoldenRatioProofMacro.self,
         Sqrt2ConvergenceProofMacro.self,
+        MulCommProofMacro.self,
     ]
 }

--- a/Tests/AbuseOfNotationMacrosTests/MulCommProofMacroTests.swift
+++ b/Tests/AbuseOfNotationMacrosTests/MulCommProofMacroTests.swift
@@ -1,0 +1,97 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(AbuseOfNotationMacros)
+import AbuseOfNotationMacros
+
+nonisolated(unsafe) let mulCommProofMacros: [String: Macro.Type] = [
+    "MulCommProof": MulCommProofMacro.self,
+]
+#endif
+
+final class MulCommProofMacroTests: XCTestCase {
+    #if canImport(AbuseOfNotationMacros)
+
+    func testLeftOperandTwoDepthTwo() throws {
+        assertMacroExpansion(
+            """
+            @MulCommProof(leftOperand: 2, depth: 2)
+            enum MulComm2 {}
+            """,
+            expandedSource: """
+            enum MulComm2 {
+
+                typealias _Fwd0 = TimesZero<AddOne<AddOne<Zero>>>
+
+                typealias _Rev0 = AddOne<AddOne<Zero>>.ZeroTimesProof
+
+                typealias _Fwd1 = TimesGroup<TimesTick<TimesTick<_Fwd0>>>
+
+                typealias _Rev1 = _Rev0.Distributed
+
+                typealias _Fwd2 = TimesGroup<TimesTick<TimesTick<_Fwd1>>>
+
+                typealias _Rev2 = _Rev1.Distributed
+            }
+            """,
+            macros: mulCommProofMacros
+        )
+    }
+
+    func testLeftOperandThreeDepthOne() throws {
+        assertMacroExpansion(
+            """
+            @MulCommProof(leftOperand: 3, depth: 1)
+            enum MulComm3 {}
+            """,
+            expandedSource: """
+            enum MulComm3 {
+
+                typealias _Fwd0 = TimesZero<AddOne<AddOne<AddOne<Zero>>>>
+
+                typealias _Rev0 = AddOne<AddOne<AddOne<Zero>>>.ZeroTimesProof
+
+                typealias _Fwd1 = TimesGroup<TimesTick<TimesTick<TimesTick<_Fwd0>>>>
+
+                typealias _Rev1 = _Rev0.Distributed
+            }
+            """,
+            macros: mulCommProofMacros
+        )
+    }
+
+    func testZeroLeftOperandProducesDiagnostic() throws {
+        assertMacroExpansion(
+            """
+            @MulCommProof(leftOperand: 0, depth: 3)
+            enum MulComm0 {}
+            """,
+            expandedSource: """
+            enum MulComm0 {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "#MulCommProof requires an integer literal >= 2", line: 1, column: 1)
+            ],
+            macros: mulCommProofMacros
+        )
+    }
+
+    func testOneLeftOperandProducesDiagnostic() throws {
+        assertMacroExpansion(
+            """
+            @MulCommProof(leftOperand: 1, depth: 3)
+            enum MulComm1 {}
+            """,
+            expandedSource: """
+            enum MulComm1 {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "#MulCommProof requires an integer literal >= 2", line: 1, column: 1)
+            ],
+            macros: mulCommProofMacros
+        )
+    }
+
+    #endif
+}


### PR DESCRIPTION
## Summary

- Add `@MulCommProof(leftOperand: A, depth: D)` member macro that generates bounded-depth paired proofs showing `A * b = b * A` for any fixed A >= 2
- Add N4 and N5 commutativity demonstrations to main.swift (4*3 = 3*4 = 12, 5*2 = 2*5 = 10)
- Add 4 macro expansion tests (leftOperand 2, leftOperand 3, zero diagnostic, one diagnostic)

## Test plan

- [x] `swift build` compiles (type checker verifies `_Fwd3.Total == _Rev3.Total == N12`)
- [x] `swift run AbuseOfNotationClient` exits cleanly
- [x] `swift test` passes all 17 tests (13 existing + 4 new)

Closes #41