### PR TITLE
Add Wallis product proof and README theoretical sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,12 @@ Sources/
     Witnesses.swift                          -- witness protocols and constructors (NaturalSum, NaturalProduct, NaturalLessThan)
     TypeLevelArithmetic.swift                -- NaturalExpression, type aliases (N0-N105), Sum, Product, _TimesNk protocols
     CayleyDickson.swift                      -- Cayley-Dickson construction (Algebra marker protocol, CayleyDickson type)
-    ContinuedFractions.swift                 -- Fraction, GCFConvergent (CF convergents), LeibnizPartialSum (Leibniz series), Matrix2x2, Mat2, Sqrt2MatStep (matrix construction)
+    ContinuedFractions.swift                 -- Fraction, GCFConvergent (CF convergents), LeibnizPartialSum (Leibniz series), WallisPartialProduct (Wallis product), Matrix2x2, Mat2, Sqrt2MatStep (matrix construction)
     Fibonacci.swift                          -- FibState, FibVerified, Fib0, FibStep (Fibonacci recurrence witnesses)
     AdditionTheorems.swift                   -- universal addition theorems (AddLeftZero, SuccLeftAdd, AddCommutative, AddAssociative via ProofSeed)
     MultiplicationTheorems.swift             -- flat multiplication witnesses (TimesTick, TimesGroup), universal theorems (MulLeftZero, SuccLeftMul, MulComm)
     Streams.swift                            -- CFStream protocol, periodic irrationals (PhiCF, Sqrt2CF), unfold theorems, assertStreamEqual
-    Macros.swift                             -- macro declarations (@ProductConformance, @FibonacciProof, @PiConvergenceProof, @GoldenRatioProof, @Sqrt2ConvergenceProof, @MulCommProof)
+    Macros.swift                             -- macro declarations (@ProductConformance, @FibonacciProof, @PiConvergenceProof, @GoldenRatioProof, @Sqrt2ConvergenceProof, @MulCommProof, @WallisProductProof)
   AbuseOfNotationMacros/                     -- .macro target: compiler plugin
     Plugin.swift                             -- CompilerPlugin entry point
     ProductConformanceMacro.swift            -- @ProductConformance(n) (peer macro for inductive multiplication)
@@ -26,7 +26,8 @@ Sources/
     GoldenRatioProofMacro.swift              -- @GoldenRatioProof(depth:) (member macro generating golden ratio CF/Fibonacci proof)
     Sqrt2ConvergenceProofMacro.swift         -- @Sqrt2ConvergenceProof(depth:) (member macro generating sqrt(2) CF/matrix proof)
     MulCommProofMacro.swift                  -- @MulCommProof(leftOperand:depth:) (member macro generating paired commutativity proofs)
-    ProductChainGenerator.swift              -- shared product witness chain generator (used by Pi, GoldenRatio, Sqrt2 macros)
+    WallisProductProofMacro.swift            -- @WallisProductProof(depth:) (member macro generating Wallis product proof)
+    ProductChainGenerator.swift              -- shared product witness chain generator (used by Pi, GoldenRatio, Sqrt2, Wallis macros)
     Diagnostics.swift                        -- PeanoDiagnostic enum
   AbuseOfNotationClient/                     -- SPM executable: witness-based proofs
     main.swift                               -- witness constructions verified by compilation, type-level arithmetic assertions
@@ -39,6 +40,7 @@ Tests/
     GoldenRatioProofMacroTests.swift
     Sqrt2ConvergenceProofMacroTests.swift
     MulCommProofMacroTests.swift
+    WallisProductProofMacroTests.swift
 ```
 
 ## Building and testing
@@ -70,6 +72,7 @@ swift test                       # run macro expansion tests
 - The `@PiConvergenceProof(depth:)` macro generates the Brouncker-Leibniz correspondence proof as members, including CF convergents, Leibniz partial sums, product/sum witnesses, and type equality assertions.
 - The `@GoldenRatioProof(depth:)` macro generates the golden ratio CF / Fibonacci correspondence proof, showing that CF [1;1,1,...] convergents h_n/k_n equal F(n+2)/F(n+1).
 - The `@Sqrt2ConvergenceProof(depth:)` macro generates the sqrt(2) CF / matrix correspondence proof, showing that CF [1;2,2,...] convergents match iterated left-multiplication by [[2,1],[1,0]] via Sqrt2MatStep.
+- The `@WallisProductProof(depth:)` macro generates the Wallis product proof: unreduced partial products W_k, two-step product decomposition (multiplying by 2k twice instead of (2k)^2 once), and a factor correspondence proving (2k-1)(2k+1) + 1 = (2k)^2 at each step. Practical depth limit is 2 (products grow fast -- depth 3 exceeds macro output limits).
 - Proof-generating macros use `@attached(member, names: arbitrary)` to scope generated types inside a namespace enum (e.g., `FibProof._Fib1`, `PiProof._CF1`).
 - The macro is the proof SEARCH (arbitrary integer computation at compile time); the type checker is the proof VERIFIER (structural constraint verification).
 - Universal theorems use conditional conformance as structural induction: a base case on `Zero`/`PlusZero` and an inductive step on `AddOne`/`PlusSucc`. Protocols use plain associated types (no `where` clauses) following the `_TimesNk` pattern to avoid rewrite system limits; correctness is enforced structurally by the conformance definitions.

--- a/Sources/AbuseOfNotation/Macros.swift
+++ b/Sources/AbuseOfNotation/Macros.swift
@@ -15,3 +15,6 @@ public macro Sqrt2ConvergenceProof(depth n: Int) = #externalMacro(module: "Abuse
 
 @attached(member, names: arbitrary)
 public macro MulCommProof(leftOperand: Int, depth: Int) = #externalMacro(module: "AbuseOfNotationMacros", type: "MulCommProofMacro")
+
+@attached(member, names: arbitrary)
+public macro WallisProductProof(depth n: Int) = #externalMacro(module: "AbuseOfNotationMacros", type: "WallisProductProofMacro")

--- a/Sources/AbuseOfNotationClient/main.swift
+++ b/Sources/AbuseOfNotationClient/main.swift
@@ -299,7 +299,38 @@ assertEqual(PiProof._LS4.Q.self, N105.self)
 // Since both sequences converge, and their values agree, they converge to
 // the same limit: pi.
 
-// MARK: - 10. Non-constant base case: Seed<A>
+// MARK: - 10. Wallis product (macro-generated proof)
+
+// The Wallis product for pi/2:
+//   pi/2 = prod_{k=1}^{inf} (2k)^2 / ((2k-1)(2k+1))
+//
+// Unreduced partial products: W_0 = 1/1, W_1 = 4/3, W_2 = 64/45, ...
+//
+// Each step multiplies the numerator by (2k)^2 and the denominator by
+// (2k-1)(2k+1). The structural fingerprint: the numerator factor exceeds
+// the denominator factor by exactly 1 at each step:
+//   (2k)^2 = (2k-1)(2k+1) + 1
+//
+// This is provable at the type level: the macro emits a PlusSucc<PlusZero<...>>
+// witness for each k. The factor correspondence is a difference-of-squares
+// identity, verified by the type checker.
+//
+// Products grow fast, so the macro uses a two-step decomposition:
+//   Numerator:   prev_p * 2k, then result * 2k
+//   Denominator: prev_q * (2k-1), then result * (2k+1)
+
+@WallisProductProof(depth: 2)
+enum WallisProof {}
+
+// Verify W_0 = 1/1:
+assertEqual(WallisProof._W0.P.self, N1.self)
+assertEqual(WallisProof._W0.Q.self, N1.self)
+
+// Verify W_1 = 4/3:
+assertEqual(WallisProof._W1.P.self, N4.self)
+assertEqual(WallisProof._W1.Q.self, N3.self)
+
+// MARK: - 11. Non-constant base case: Seed<A>
 
 // The _TimesN2 pattern has a constant base case: Zero._TimesN2Result = Zero.
 // By introducing Seed<A> — a parameterized type that conforms to Natural —
@@ -316,7 +347,7 @@ assertEqual(Seed<N0>._Sum.self, N0.self)
 assertEqual(Seed<N9>._Sum.self, N9.self)
 assertEqual(AddOne<AddOne<AddOne<Seed<N4>>>>._Sum.self, N7.self)  // 4 + 3 = 7
 
-// MARK: - 11. Fibonacci at the type level (macro-generated proof)
+// MARK: - 12. Fibonacci at the type level (macro-generated proof)
 
 // The FibVerified protocol uses a where clause on its SumWitness
 // associated type to force Next == Prev + Current. Each FibStep
@@ -340,7 +371,7 @@ assertEqual(FibProof._Fib4.Current.self, N3.self)  // F(4) = 3
 assertEqual(FibProof._Fib5.Current.self, N5.self)  // F(5) = 5
 assertEqual(FibProof._Fib6.Current.self, N8.self)  // F(6) = 8
 
-// MARK: - 12. Golden ratio and Fibonacci (macro-generated proof)
+// MARK: - 13. Golden ratio and Fibonacci (macro-generated proof)
 
 // The golden ratio phi = (1 + sqrt(5))/2 has the simplest continued fraction:
 //   phi = [1; 1, 1, 1, ...]
@@ -371,7 +402,7 @@ assertEqual(GoldenRatioProof._CF4.Q.self, N5.self)   // k_4 = 5 = F(5)
 assertEqual(GoldenRatioProof._CF5.P.self, N13.self)  // h_5 = 13 = F(7)
 assertEqual(GoldenRatioProof._CF5.Q.self, N8.self)   // k_5 = 8 = F(6)
 
-// MARK: - 13. sqrt(2) CF and matrix construction (macro-generated proof)
+// MARK: - 14. sqrt(2) CF and matrix construction (macro-generated proof)
 
 // The continued fraction for sqrt(2) is [1; 2, 2, 2, ...]:
 //   sqrt(2) = 1 + 1/(2 + 1/(2 + 1/(2 + ...)))
@@ -410,7 +441,7 @@ assertEqual(Sqrt2Proof._MAT2.B.self, N5.self)   // MAT2 top-right = k_2 = 5
 assertEqual(Sqrt2Proof._MAT3.A.self, N17.self)  // MAT3 top-left = h_3 = 17
 assertEqual(Sqrt2Proof._MAT3.B.self, N12.self)  // MAT3 top-right = k_3 = 12
 
-// MARK: - 14. Universal addition theorems (structural induction)
+// MARK: - 15. Universal addition theorems (structural induction)
 //
 // Unlike the proofs above (which verify specific values), these theorems
 // hold for ALL natural numbers. The proof is conditional conformance:
@@ -485,7 +516,7 @@ assertEqual(ThreePlusThree.Commuted.Left.self, N3.self)
 assertEqual(ThreePlusThree.Commuted.Right.self, N3.self)
 assertEqual(ThreePlusThree.Commuted.Total.self, N6.self)
 
-// MARK: - 15. Associativity of addition (ProofSeed)
+// MARK: - 16. Associativity of addition (ProofSeed)
 //
 // Associativity -- (a + b) + c = a + (b + c) -- is a binary theorem: it
 // requires TWO addition proofs (one for a+b, one for the result plus c).
@@ -536,7 +567,7 @@ assertEqual(Assoc2p3p2.AssocProof.Total.self, N7.self)      // d + c = 5 + 2 = 7
 typealias FivePlusTwo = PlusSucc<PlusSucc<PlusZero<N5>>>
 assertEqual(Assoc2p3p2.AssocProof.Total.self, FivePlusTwo.Total.self)
 
-// MARK: - 16. Universal multiplication theorems (structural induction)
+// MARK: - 17. Universal multiplication theorems (structural induction)
 //
 // TimesSucc has where clauses that trigger rewrite system explosion when
 // composed in inductive protocols. The flat encoding (TimesTick/TimesGroup)
@@ -685,7 +716,7 @@ assertEqual(MulComm5._Fwd2.Right.self, N2.self)
 assertEqual(MulComm5._Rev2.Left.self, N2.self)   // 2 * 5
 assertEqual(MulComm5._Rev2.Right.self, N5.self)
 
-// MARK: - 17. Coinductive streams for irrational numbers
+// MARK: - 18. Coinductive streams for irrational numbers
 //
 // The proofs above represent irrational numbers through bounded-depth
 // convergent chains (macro-generated). Coinductive streams provide a
@@ -766,9 +797,10 @@ assertEqual(Sqrt2CF.Head.self, Sqrt2Proof._CF0.P.self)         // both N1
 // means every assertEqual call above unified its type arguments and every
 // witness type satisfied its protocol constraints. The compiler verified
 // 100+ mathematical facts about natural numbers, their arithmetic,
-// continued fractions, the Leibniz series, the golden ratio / Fibonacci
-// correspondence, the sqrt(2) CF / matrix construction, four universal
-// addition theorems (left zero identity, successor-left shift,
+// continued fractions, the Leibniz series, the Wallis product (with its
+// difference-of-squares factor correspondence), the golden ratio /
+// Fibonacci correspondence, the sqrt(2) CF / matrix construction, four
+// universal addition theorems (left zero identity, successor-left shift,
 // commutativity, and associativity), three universal multiplication
 // theorems (left zero annihilation, successor-left multiplication, and
 // per-A commutativity -- including macro-generated proofs for N4 and N5),

--- a/Sources/AbuseOfNotationMacros/Diagnostics.swift
+++ b/Sources/AbuseOfNotationMacros/Diagnostics.swift
@@ -7,6 +7,7 @@ enum PeanoDiagnostic: String, DiagnosticMessage {
     case goldenRatioRequiresPositiveInteger = "#goldenRatioProof requires an integer literal >= 1"
     case sqrt2ConvergenceRequiresPositiveInteger = "#sqrt2ConvergenceProof requires an integer literal >= 1"
     case mulCommProofRequiresMultiplier = "#MulCommProof requires an integer literal >= 2"
+    case wallisProductRequiresPositiveInteger = "#wallisProductProof requires an integer literal >= 1"
 
     var message: String { rawValue }
     var diagnosticID: MessageID { MessageID(domain: "AbuseOfNotationMacros", id: rawValue) }

--- a/Sources/AbuseOfNotationMacros/Plugin.swift
+++ b/Sources/AbuseOfNotationMacros/Plugin.swift
@@ -10,5 +10,6 @@ struct AbuseOfNotationPlugin: CompilerPlugin {
         GoldenRatioProofMacro.self,
         Sqrt2ConvergenceProofMacro.self,
         MulCommProofMacro.self,
+        WallisProductProofMacro.self,
     ]
 }

--- a/Sources/AbuseOfNotationMacros/WallisProductProofMacro.swift
+++ b/Sources/AbuseOfNotationMacros/WallisProductProofMacro.swift
@@ -1,0 +1,125 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// `@WallisProductProof(depth: n)` -- generates the Wallis product proof to depth n.
+///
+/// The Wallis product for pi/2:
+///   pi/2 = prod_{k=1}^{inf} (2k)^2 / ((2k-1)(2k+1))
+///
+/// At compile time, the macro computes:
+///   1. Unreduced partial products W_0 = 1/1, W_1 = 4/3, W_2 = 64/45, ...
+///   2. Two-step product decomposition: prev_p * 2k then result * 2k (numerator),
+///      prev_q * (2k-1) then result * (2k+1) (denominator)
+///   3. All NaturalProduct witnesses via ProductChainGenerator
+///   4. WallisStep chain linking each step to the previous
+///   5. Factor correspondence: for each k, (2k-1)(2k+1) + 1 = (2k)^2
+///      witnessed by a PlusSucc<PlusZero<...>> chain
+///
+/// The type checker independently verifies every witness chain.
+public struct WallisProductProofMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+              let argument = arguments.first?.expression,
+              let literal = argument.as(IntegerLiteralExprSyntax.self),
+              let depth = Int(literal.literal.text),
+              depth >= 1 else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(node: Syntax(node), message: PeanoDiagnostic.wallisProductRequiresPositiveInteger)
+            ])
+        }
+
+        // --- Compute unreduced Wallis partial products ---
+        // W_0 = 1/1
+        // W_k = W_{k-1} * (2k)^2 / ((2k-1)(2k+1))
+        var WP = [1]  // numerators
+        var WQ = [1]  // denominators
+
+        for k in 1...depth {
+            let twoK = 2 * k
+            let numFactor = twoK * twoK          // (2k)^2
+            let denFactor = (twoK - 1) * (twoK + 1)  // (2k-1)(2k+1)
+            WP.append(WP[k - 1] * numFactor)
+            WQ.append(WQ[k - 1] * denFactor)
+        }
+
+        // --- Collect needed product chains ---
+        // Two-step decomposition: for each k,
+        //   Numerator:   prev_p * 2k, then (prev_p * 2k) * 2k
+        //   Denominator: prev_q * (2k-1), then (prev_q * (2k-1)) * (2k+1)
+        var gen = ProductChainGenerator()
+
+        for k in 1...depth {
+            let twoK = 2 * k
+            let twoKm1 = twoK - 1
+            let twoKp1 = twoK + 1
+
+            let prevP = WP[k - 1]
+            let prevQ = WQ[k - 1]
+            let midP = prevP * twoK     // prev_p * 2k
+            let midQ = prevQ * twoKm1   // prev_q * (2k-1)
+
+            gen.need(factor: prevP, multiplier: twoK)     // prev_p * 2k
+            gen.need(factor: midP, multiplier: twoK)      // (prev_p * 2k) * 2k
+            gen.need(factor: prevQ, multiplier: twoKm1)   // prev_q * (2k-1)
+            gen.need(factor: midQ, multiplier: twoKp1)    // (prev_q * (2k-1)) * (2k+1)
+        }
+
+        // --- Generate product chains ---
+        var decls: [DeclSyntax] = gen.declarations()
+
+        // --- Generate Wallis step chain ---
+        let w0: DeclSyntax = "typealias _W0 = WallisBase"
+        decls.append(w0)
+
+        for k in 1...depth {
+            let twoK = 2 * k
+            let twoKm1 = twoK - 1
+            let twoKp1 = twoK + 1
+
+            let prevP = WP[k - 1]
+            let prevQ = WQ[k - 1]
+            let midP = prevP * twoK
+            let midQ = prevQ * twoKm1
+
+            let pTimesTwoK = ProductChainGenerator.name(factor: prevP, multiplier: twoK)
+            let midPTimesTwoK = ProductChainGenerator.name(factor: midP, multiplier: twoK)
+            let qTimesTwoKm1 = ProductChainGenerator.name(factor: prevQ, multiplier: twoKm1)
+            let midQTimesTwoKp1 = ProductChainGenerator.name(factor: midQ, multiplier: twoKp1)
+
+            let wDecl: DeclSyntax = "typealias _W\(raw: String(k)) = WallisStep<_W\(raw: String(k - 1)), \(raw: pTimesTwoK), \(raw: midPTimesTwoK), \(raw: qTimesTwoKm1), \(raw: midQTimesTwoKp1)>"
+            decls.append(wDecl)
+        }
+
+        // --- Generate factor correspondence ---
+        // For each k: (2k-1)(2k+1) + 1 = (2k)^2
+        // Witnessed by PlusSucc<PlusZero<peano((2k-1)(2k+1))>>
+        for k in 1...depth {
+            let twoK = 2 * k
+            let denFactor = (twoK - 1) * (twoK + 1)  // left
+            let witness = plusSuccChain(left: denFactor, right: 1)
+            let fcDecl: DeclSyntax = "typealias _WFC\(raw: String(k)) = \(raw: witness)"
+            decls.append(fcDecl)
+        }
+
+        // --- Generate factor check function ---
+        var body = ""
+        for k in 1...depth {
+            let twoK = 2 * k
+            let numFactor = twoK * twoK
+            let peano = peanoTypeName(for: numFactor)
+            body += "    assertEqual(_WFC\(k).Total.self, \(peano).self)\n"
+        }
+        let checkDecl: DeclSyntax = """
+        func _wallisFactorCheck() {
+        \(raw: body)}
+        """
+        decls.append(checkDecl)
+
+        return decls
+    }
+}

--- a/Tests/AbuseOfNotationMacrosTests/WallisProductProofMacroTests.swift
+++ b/Tests/AbuseOfNotationMacrosTests/WallisProductProofMacroTests.swift
@@ -1,0 +1,73 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(AbuseOfNotationMacros)
+import AbuseOfNotationMacros
+
+nonisolated(unsafe) let wallisProductProofMacros: [String: Macro.Type] = [
+    "WallisProductProof": WallisProductProofMacro.self,
+]
+#endif
+
+final class WallisProductProofMacroTests: XCTestCase {
+    #if canImport(AbuseOfNotationMacros)
+
+    func testDepthOne() throws {
+        // Depth 1: W_0 = 1/1, W_1 = 4/3
+        // Factor correspondence: (2*1-1)(2*1+1) + 1 = (2*1)^2, i.e. 3 + 1 = 4
+        assertMacroExpansion(
+            """
+            @WallisProductProof(depth: 1)
+            enum WallisProof {}
+            """,
+            expandedSource: """
+            enum WallisProof {
+
+                typealias _M1x0 = TimesZero<AddOne<Zero>>
+
+                typealias _M1x1 = TimesSucc<_M1x0, PlusSucc<PlusZero<Zero>>>
+
+                typealias _M1x2 = TimesSucc<_M1x1, PlusSucc<PlusZero<AddOne<Zero>>>>
+
+                typealias _M1x3 = TimesSucc<_M1x2, PlusSucc<PlusZero<AddOne<AddOne<Zero>>>>>
+
+                typealias _M2x0 = TimesZero<AddOne<AddOne<Zero>>>
+
+                typealias _M2x1 = TimesSucc<_M2x0, PlusSucc<PlusSucc<PlusZero<Zero>>>>
+
+                typealias _M2x2 = TimesSucc<_M2x1, PlusSucc<PlusSucc<PlusZero<AddOne<AddOne<Zero>>>>>>
+
+                typealias _W0 = WallisBase
+
+                typealias _W1 = WallisStep<_W0, _M1x2, _M2x2, _M1x1, _M1x3>
+
+                typealias _WFC1 = PlusSucc<PlusZero<AddOne<AddOne<AddOne<Zero>>>>>
+
+                func _wallisFactorCheck() {
+                    assertEqual(_WFC1.Total.self, AddOne<AddOne<AddOne<AddOne<Zero>>>>.self)
+                }
+            }
+            """,
+            macros: wallisProductProofMacros
+        )
+    }
+
+    func testZeroProducesDiagnostic() throws {
+        assertMacroExpansion(
+            """
+            @WallisProductProof(depth: 0)
+            enum WallisProof {}
+            """,
+            expandedSource: """
+            enum WallisProof {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "#wallisProductProof requires an integer literal >= 1", line: 1, column: 1)
+            ],
+            macros: wallisProductProofMacros
+        )
+    }
+
+    #endif
+}


### PR DESCRIPTION
## Summary

- Add the Wallis product as a third pi construction proved at the type level, with `WallisPartialProduct` protocol, `WallisBase`/`WallisStep` types, and `@WallisProductProof(depth:)` macro
- Add two-step product decomposition (multiplying by 2k twice instead of (2k)^2 once) and difference-of-squares factor correspondence ((2k-1)(2k+1) + 1 = (2k)^2)
- Add README sections: "A split dependent type system" and "Limitations and the universality gap"

## Test plan

- [x] `swift build` compiles (compilation = proof)
- [x] `swift run AbuseOfNotationClient` exits cleanly
- [x] `swift test` passes all 19 macro expansion tests (including 2 new Wallis tests)
- [x] Wallis macro expansion verified at depth 1 (`testDepthOne`)
- [x] Invalid depth produces diagnostic (`testZeroProducesDiagnostic`)

Closes #43