### PR TITLE
Deploy tutorial to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-tutorial.yml
+++ b/.github/workflows/deploy-tutorial.yml
@@ -1,0 +1,50 @@
+name: Deploy tutorial
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'tutorial/**'
+      - '.github/workflows/deploy-tutorial.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tutorial
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tutorial/package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: tutorial/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -7,12 +7,12 @@
   <meta name="description" content="A guided tour through encoding natural numbers and mathematical proofs as Swift types. Compilation is verification.">
   <meta property="og:title" content="Abuse of Notation: A Tutorial">
   <meta property="og:description" content="Compile-time proof verification in the Swift type system.">
-  <meta property="og:image" content="/og-image.png">
+  <meta property="og:image" content="https://abuseofnotation.funlandresearch.com/og-image.png">
   <meta property="og:type" content="article">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Abuse of Notation: A Tutorial">
   <meta name="twitter:description" content="Compile-time proof verification in the Swift type system.">
-  <meta name="twitter:image" content="/og-image.png">
+  <meta name="twitter:image" content="https://abuseofnotation.funlandresearch.com/og-image.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Source+Code+Pro:wght@400;500;600&display=swap" rel="stylesheet">

--- a/tutorial/public/CNAME
+++ b/tutorial/public/CNAME
@@ -1,0 +1,1 @@
+abuseofnotation.funlandresearch.com


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and deploy the Vite tutorial site to Pages on push to master
- Add CNAME for `abuseofnotation.funlandresearch.com`
- Add OG preview image ("t ∈ ⟦Swift⟧") with absolute URL meta tags

## Setup required after merge
1. Repo Settings > Pages > Source: select **GitHub Actions**
2. DNS: add CNAME record `abuseofnotation` → `jakebromberg.github.io`

## Test plan
- [ ] Merge and verify the workflow runs successfully
- [ ] Confirm site is accessible at `abuseofnotation.funlandresearch.com`
- [ ] Share URL on Slack/Twitter to verify OG preview image

Closes #75