### PR TITLE
Fix diagram 404s: generate SVGs in deploy workflow

### DIFF
--- a/.github/workflows/deploy-tutorial.yml
+++ b/.github/workflows/deploy-tutorial.yml
@@ -32,7 +32,11 @@ jobs:
           cache: npm
           cache-dependency-path: tutorial/package-lock.json
 
+      - name: Install d2
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+
       - run: npm ci
+      - run: npm run diagrams
       - run: npm run build
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Install d2 CLI in the deploy workflow
- Run `npm run diagrams` before `npm run build` to generate the SVGs that are gitignored

## Test plan
- [ ] Merge and verify diagrams load at abuseofnotation.funlandresearch.com

Closes #77